### PR TITLE
improve OCP detection + speed up legacy playback start

### DIFF
--- a/ocp_pipeline/opm.py
+++ b/ocp_pipeline/opm.py
@@ -771,6 +771,7 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                 if s.session_id == player.session_id:
                     player.available_extractors = m.data["SEI"]
                     player.ocp_available = True
+                    self.update_player_proxy(player)
                     ev.set()
                     LOG.info(f"Session: {player.session_id} Available stream extractor plugins: {m.data['SEI']}")
 
@@ -780,7 +781,6 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             ev.wait(timeout)
             self.bus.remove("ovos.common_play.SEI.get.response", handle_m)
 
-        self.update_player_proxy(player)
         return player
 
     def get_player(self, message: Optional[Message] = None, timeout=1) -> OCPPlayerProxy:

--- a/ocp_pipeline/opm.py
+++ b/ocp_pipeline/opm.py
@@ -781,8 +781,10 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             ev.wait(timeout)
             self.bus.remove("ovos.common_play.SEI.get.response", handle_m)
 
-        return player
+            if not ev.is_set():
+                LOG.warning(f"Player synchronization timed out after {timeout} seconds")
 
+        return player
     def get_player(self, message: Optional[Message] = None, timeout=1) -> OCPPlayerProxy:
         """get a PlayerProxy object, containing info such as player state and the available stream extractors from OCP
         this is tracked per Session, if needed requests the info from the client"""


### PR DESCRIPTION
improve OCP detection + speed up legacy playback start + add LOGs

related issues:
- not detecting installed OCP and always using legacy player -> fixed https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/pull/159
- legacy playback hangs extracting stream forever, offending stream removed https://github.com/OpenVoiceOS/ovos-skill-news/pull/53


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced player synchronization for improved media handling.
  - Added robust error handling for URI extraction during playback.

- **Bug Fixes**
  - Improved handling of media entries and playlists to ensure correct player state updates.

- **Refactor**
  - Streamlined method signatures and improved type safety with new type aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->