### PR TITLE
feat: save/load game intent

### DIFF
--- a/ocp_pipeline/locale/en-us/load_game.intent
+++ b/ocp_pipeline/locale/en-us/load_game.intent
@@ -1,0 +1,2 @@
+load
+load [the] game

--- a/ocp_pipeline/locale/en-us/load_game.intent
+++ b/ocp_pipeline/locale/en-us/load_game.intent
@@ -1,2 +1,3 @@
 load
 load [the] game
+load [the] (last|previous) [saved] game

--- a/ocp_pipeline/locale/en-us/next.intent
+++ b/ocp_pipeline/locale/en-us/next.intent
@@ -4,3 +4,4 @@
 next
 next (song|track|music|movie|video|tune)
 play next
+play [the] next (song|track|music|movie|video|tune)

--- a/ocp_pipeline/locale/en-us/next.intent
+++ b/ocp_pipeline/locale/en-us/next.intent
@@ -4,4 +4,4 @@
 next
 next (song|track|music|movie|video|tune)
 play next
-play [the] next (song|track|music|movie|video|tune)
+(play|go to) [the] next (song|track|music|movie|video|tune)

--- a/ocp_pipeline/locale/en-us/open.intent
+++ b/ocp_pipeline/locale/en-us/open.intent
@@ -1,4 +1,4 @@
 open (OCP|O C P|common|ovos|open voice os) (player|media player)
 open (OCP|O C P|ovos common play|common play|ovos media player|open voice os player) (home screen|home page|homescreen|homepage|menu)
 open (OCP|O C P|ovos common play|open voice os common play|common play)
-open (media|music|gui|video) (player|catalog|skills|menu|playback)
+open [the] (media|music|gui|video) (player|catalog|skills|menu|playback)

--- a/ocp_pipeline/locale/en-us/pause.intent
+++ b/ocp_pipeline/locale/en-us/pause.intent
@@ -1,2 +1,2 @@
 pause
-pause (music|song|track|video|media|playback)
+pause [the] (music|song|track|video|media|playback|game)

--- a/ocp_pipeline/locale/en-us/prev.intent
+++ b/ocp_pipeline/locale/en-us/prev.intent
@@ -3,4 +3,4 @@
 (play previous|previous|go back)
 previous
 previous (song|track|music|movie|video|tune)
-play [the] previous (song|track|music|movie|video|tune)
+(play|go to) [the] previous (song|track|music|movie|video|tune)

--- a/ocp_pipeline/locale/en-us/prev.intent
+++ b/ocp_pipeline/locale/en-us/prev.intent
@@ -3,3 +3,4 @@
 (play previous|previous|go back)
 previous
 previous (song|track|music|movie|video|tune)
+play [the] previous (song|track|music|movie|video|tune)

--- a/ocp_pipeline/locale/en-us/read.intent
+++ b/ocp_pipeline/locale/en-us/read.intent
@@ -1,3 +1,3 @@
-read (book|audiobook|audio book) {query}
+read [the] (book|audiobook|audio book) {query}
 read {query}
 read {query} (book|audiobook|audio book)

--- a/ocp_pipeline/locale/en-us/resume.intent
+++ b/ocp_pipeline/locale/en-us/resume.intent
@@ -1,3 +1,3 @@
 (unpause|resume)
-(unpause|resume|continue|restart) (music|song|track|video|media|playback)
+(unpause|resume|continue|restart) [the] (music|song|track|video|media|playback|game)
 play

--- a/ocp_pipeline/locale/en-us/save_game.intent
+++ b/ocp_pipeline/locale/en-us/save_game.intent
@@ -1,0 +1,2 @@
+save
+save [the] game

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ovos-workshop>=0.1.7,<4.0.0
 ovos-classifiers
-ovos-utils>=0.3.5,<1.0.0
+ovos-utils[extras]>=0.3.5,<1.0.0
 ovos-plugin-manager>=0.5.0,<1.0.0
-langcodes

--- a/translations/en-us/intents.json
+++ b/translations/en-us/intents.json
@@ -23,7 +23,7 @@
     ],
     "resume.intent": [
         "(unpause|resume)",
-        "(unpause|resume|continue|restart) (music|song|track|video|media|playback|game)",
+        "(unpause|resume|continue|restart) [ŧhe] (music|song|track|video|media|playback|game)",
         "play"
     ],
     "read.intent": [
@@ -47,7 +47,7 @@
         "open (OCP|O C P|common|ovos|open voice os) (player|media player)",
         "open (OCP|O C P|ovos common play|common play|ovos media player|open voice os player) (home screen|home page|homescreen|homepage|menu)",
         "open (OCP|O C P|ovos common play|open voice os common play|common play)",
-        "open (media|music|gui|video) (player|catalog|skills|menu|playback)"
+        "open [the] (media|music|gui|video) (player|catalog|skills|menu|playback)"
     ],
     "featured.intent": [
         "(open|show|display) (featured|) {media} (catalog|collection|playlist)",

--- a/translations/en-us/intents.json
+++ b/translations/en-us/intents.json
@@ -1,4 +1,42 @@
 {
+    "featured.intent": [
+        "(open|show|display) (featured|) {media} (catalog|collection|playlist)",
+        "(open|show|display) featured {media}"
+    ],
+    "like_song.intent": [
+        "(good|nice|great|amazing|awesome|cool) (song|music|track|jam|sound)",
+        "(that|this|it) is a (good|nice|great|amazing|awesome|cool) (song|music|track|jam|sound)",
+        "i like (that|this)(song|music|track|jam|sound)",
+        "i like (that|this|it)"
+    ],
+    "load_game.intent": [
+        "load",
+        "load [the] game"
+    ],
+    "media_stop.intent": [
+        "stop",
+        "stop (playback|media|media playback|music|movie|movies|noise)",
+        "stop everything"
+    ],
+    "next.intent": [
+        "(next|skip)",
+        "(next|skip) (music|song|track|video|media)",
+        "(play|go to) next (music|song|track|video|media)",
+        "next",
+        "next (song|track|music|movie|video|tune)",
+        "play [the] next (song|track|music|movie|video|tune)",
+        "play next"
+    ],
+    "open.intent": [
+        "open (OCP|O C P|common|ovos|open voice os) (player|media player)",
+        "open (OCP|O C P|ovos common play|common play|ovos media player|open voice os player) (home screen|home page|homescreen|homepage|menu)",
+        "open (OCP|O C P|ovos common play|open voice os common play|common play)",
+        "open [the] (media|music|gui|video) (player|catalog|skills|menu|playback)"
+    ],
+    "pause.intent": [
+        "pause",
+        "pause [the] (music|song|track|video|media|playback|game)"
+    ],
     "play.intent": [
         "(play|start) {query}",
         "search (common play|ocp|ovos common play|O C P) for {query}",
@@ -6,58 +44,30 @@
         "search {query} (in|on) (common play|ocp|ovos common play|O C P)",
         "search {query} (in|on) (ovos|open voice os) media"
     ],
-    "like_song.intent": [
-        "i like (that|this|it)",
-        "i like (that|this)(song|music|track|jam|sound)",
-        "(good|nice|great|amazing|awesome|cool) (song|music|track|jam|sound)",
-        "(that|this|it) is a (good|nice|great|amazing|awesome|cool) (song|music|track|jam|sound)"
-    ],
-    "next.intent": [
-        "(next|skip)",
-        "(next|skip) (music|song|track|video|media)",
-        "(play|go to) next (music|song|track|video|media)",
-        "play next",
-        "next",
-        "next (song|track|music|movie|video|tune)"
-    ],
-    "resume.intent": [
-        "(unpause|resume)",
-        "(unpause|resume|continue|restart) (music|song|track|video|media|playback)",
-        "play"
-    ],
-    "read.intent": [
-        "read (book|audiobook|audio book) {query}",
-        "read {query}",
-        "read {query} (book|audiobook|audio book)"
+    "play_favorites.intent": [
+        "(play|start) (favorite|liked) (tracks|song|songs|music|jam|jams)",
+        "(play|start) my (favorite|liked) (tracks|song|songs|music|jam|jams)"
     ],
     "prev.intent": [
         "(play previous|go back one) (music|song|track|video|media)",
         "(play previous|previous) (music|song|track|video|media)",
         "(play previous|previous|go back)",
+        "play [the] previous (song|track|music|movie|video|tune)",
         "previous",
         "previous (song|track|music|movie|video|tune)"
     ],
-    "pause.intent": [
-        "pause",
-        "pause (music|song|track|video|media|playback)"
+    "read.intent": [
+        "read [the] (book|audiobook|audio book) {query}",
+        "read {query}",
+        "read {query} (book|audiobook|audio book)"
     ],
-    "open.intent": [
-        "open (OCP|O C P|common|ovos|open voice os) (player|media player)",
-        "open (OCP|O C P|ovos common play|common play|ovos media player|open voice os player) (home screen|home page|homescreen|homepage|menu)",
-        "open (OCP|O C P|ovos common play|open voice os common play|common play)",
-        "open (media|music|gui|video) (player|catalog|skills|menu|playback)"
+    "resume.intent": [
+        "(unpause|resume)",
+        "(unpause|resume|continue|restart) [the] (music|song|track|video|media|playback|game)",
+        "play"
     ],
-    "featured.intent": [
-        "(open|show|display) (featured|) {media} (catalog|collection|playlist)",
-        "(open|show|display) featured {media}"
-    ],
-    "play_favorites.intent": [
-        "(play|start) my (favorite|liked) (tracks|song|songs|music|jam|jams)",
-        "(play|start) (favorite|liked) (tracks|song|songs|music|jam|jams)"
-    ],
-    "media_stop.intent": [
-        "stop",
-        "stop (playback|media|media playback|music|movie|movies|noise)",
-        "stop everything"
+    "save_game.intent": [
+        "save",
+        "save [the] game"
     ]
 }

--- a/translations/en-us/intents.json
+++ b/translations/en-us/intents.json
@@ -1,42 +1,4 @@
 {
-    "featured.intent": [
-        "(open|show|display) (featured|) {media} (catalog|collection|playlist)",
-        "(open|show|display) featured {media}"
-    ],
-    "like_song.intent": [
-        "(good|nice|great|amazing|awesome|cool) (song|music|track|jam|sound)",
-        "(that|this|it) is a (good|nice|great|amazing|awesome|cool) (song|music|track|jam|sound)",
-        "i like (that|this)(song|music|track|jam|sound)",
-        "i like (that|this|it)"
-    ],
-    "load_game.intent": [
-        "load",
-        "load [the] game"
-    ],
-    "media_stop.intent": [
-        "stop",
-        "stop (playback|media|media playback|music|movie|movies|noise)",
-        "stop everything"
-    ],
-    "next.intent": [
-        "(next|skip)",
-        "(next|skip) (music|song|track|video|media)",
-        "(play|go to) next (music|song|track|video|media)",
-        "next",
-        "next (song|track|music|movie|video|tune)",
-        "play [the] next (song|track|music|movie|video|tune)",
-        "play next"
-    ],
-    "open.intent": [
-        "open (OCP|O C P|common|ovos|open voice os) (player|media player)",
-        "open (OCP|O C P|ovos common play|common play|ovos media player|open voice os player) (home screen|home page|homescreen|homepage|menu)",
-        "open (OCP|O C P|ovos common play|open voice os common play|common play)",
-        "open [the] (media|music|gui|video) (player|catalog|skills|menu|playback)"
-    ],
-    "pause.intent": [
-        "pause",
-        "pause [the] (music|song|track|video|media|playback|game)"
-    ],
     "play.intent": [
         "(play|start) {query}",
         "search (common play|ocp|ovos common play|O C P) for {query}",
@@ -44,30 +6,69 @@
         "search {query} (in|on) (common play|ocp|ovos common play|O C P)",
         "search {query} (in|on) (ovos|open voice os) media"
     ],
-    "play_favorites.intent": [
-        "(play|start) (favorite|liked) (tracks|song|songs|music|jam|jams)",
-        "(play|start) my (favorite|liked) (tracks|song|songs|music|jam|jams)"
+    "like_song.intent": [
+        "i like (that|this|it)",
+        "i like (that|this)(song|music|track|jam|sound)",
+        "(good|nice|great|amazing|awesome|cool) (song|music|track|jam|sound)",
+        "(that|this|it) is a (good|nice|great|amazing|awesome|cool) (song|music|track|jam|sound)"
     ],
-    "prev.intent": [
-        "(play previous|go back one) (music|song|track|video|media)",
-        "(play previous|previous) (music|song|track|video|media)",
-        "(play previous|previous|go back)",
-        "play [the] previous (song|track|music|movie|video|tune)",
-        "previous",
-        "previous (song|track|music|movie|video|tune)"
+    "next.intent": [
+        "(next|skip)",
+        "(next|skip) (music|song|track|video|media)",
+        "(play|go to) next (music|song|track|video|media)",
+        "play next",
+        "next",
+        "next (song|track|music|movie|video|tune)",
+        "(play|go to) [the] next (song|track|music|movie|video|tune)"
+    ],
+    "resume.intent": [
+        "(unpause|resume)",
+        "(unpause|resume|continue|restart) (music|song|track|video|media|playback|game)",
+        "play"
     ],
     "read.intent": [
         "read [the] (book|audiobook|audio book) {query}",
         "read {query}",
         "read {query} (book|audiobook|audio book)"
     ],
-    "resume.intent": [
-        "(unpause|resume)",
-        "(unpause|resume|continue|restart) [the] (music|song|track|video|media|playback|game)",
-        "play"
+    "prev.intent": [
+        "(play previous|go back one) (music|song|track|video|media)",
+        "(play previous|previous) (music|song|track|video|media)",
+        "(play previous|previous|go back)",
+        "(play|go to) [the] previous (song|track|music|movie|video|tune)",
+        "previous",
+        "previous (song|track|music|movie|video|tune)"
+    ],
+    "pause.intent": [
+        "pause",
+        "pause [the] (music|song|track|video|media|playback|game)"
+    ],
+    "open.intent": [
+        "open (OCP|O C P|common|ovos|open voice os) (player|media player)",
+        "open (OCP|O C P|ovos common play|common play|ovos media player|open voice os player) (home screen|home page|homescreen|homepage|menu)",
+        "open (OCP|O C P|ovos common play|open voice os common play|common play)",
+        "open (media|music|gui|video) (player|catalog|skills|menu|playback)"
+    ],
+    "featured.intent": [
+        "(open|show|display) (featured|) {media} (catalog|collection|playlist)",
+        "(open|show|display) featured {media}"
+    ],
+    "play_favorites.intent": [
+        "(play|start) my (favorite|liked) (tracks|song|songs|music|jam|jams)",
+        "(play|start) (favorite|liked) (tracks|song|songs|music|jam|jams)"
+    ],
+    "media_stop.intent": [
+        "stop",
+        "stop (playback|media|media playback|music|movie|movies|noise)",
+        "stop everything"
     ],
     "save_game.intent": [
         "save",
         "save [the] game"
+    ],
+    "load_game.intent": [
+        "load",
+        "load [the] game",
+        "load [the] (last|previous) [saved] game"
     ]
 }

--- a/translations/en-us/intents.json
+++ b/translations/en-us/intents.json
@@ -23,7 +23,7 @@
     ],
     "resume.intent": [
         "(unpause|resume)",
-        "(unpause|resume|continue|restart) [ŧhe] (music|song|track|video|media|playback|game)",
+"(unpause|resume|continue|restart) [the] (music|song|track|video|media|playback|game)",
         "play"
     ],
     "read.intent": [


### PR DESCRIPTION
improve intent matching when games are the active media

NOTE: skills dont need to report if they implemented save functionality or not, a default error dialog is implemented as part of the base class, we should still match the intent if that is what the user wants regardless of being able to fulfill the order or not

https://github.com/OpenVoiceOS/OVOS-workshop/pull/306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced new commands for loading and saving games.
	- Expanded media control commands to include options for pausing and resuming games.
	- Added flexibility in media playback commands with optional articles and expanded media types.
	- Added new intent for displaying featured media collections.
	- Enhanced intent definitions for navigating to previous and next media items.

- **Bug Fixes**
	- Improved intent recognition for various media commands, ensuring more accurate user interactions.

- **Documentation**
	- Updated intent definitions to reflect new and modified commands for enhanced user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->