### PR TITLE
fix:locale_matching

### DIFF
--- a/ocp_pipeline/locale/it-it/ASMRKeyword.voc
+++ b/ocp_pipeline/locale/it-it/ASMRKeyword.voc
@@ -1,2 +1,1 @@
 ASMR
-[UNUSED]

--- a/ocp_pipeline/locale/it-it/ComicBookKeyword.voc
+++ b/ocp_pipeline/locale/it-it/ComicBookKeyword.voc
@@ -1,3 +1,2 @@
-[UNUSED]
 fumetto
 fumetto

--- a/ocp_pipeline/locale/it-it/MusicKeyword.voc
+++ b/ocp_pipeline/locale/it-it/MusicKeyword.voc
@@ -1,4 +1,3 @@
-[UNUSED]
 canzone
 colonna sonora
 musica

--- a/ocp_pipeline/locale/it-it/audio_only.voc
+++ b/ocp_pipeline/locale/it-it/audio_only.voc
@@ -1,5 +1,3 @@
-[UNUSED]
-[UNUSED]
 no video
 solo audio
 solo suono

--- a/ocp_pipeline/locale/it-it/featured.intent
+++ b/ocp_pipeline/locale/it-it/featured.intent
@@ -1,2 +1,0 @@
-[UNUSED]
-[UNUSED]

--- a/ocp_pipeline/locale/pt-pt/MovieKeyword.voc
+++ b/ocp_pipeline/locale/pt-pt/MovieKeyword.voc
@@ -1,2 +1,1 @@
-[UNUSED]
 filme

--- a/ocp_pipeline/locale/pt-pt/MusicKeyword.voc
+++ b/ocp_pipeline/locale/pt-pt/MusicKeyword.voc
@@ -1,4 +1,3 @@
-[UNUSED]
 banda sonora
 canção
 musica

--- a/ocp_pipeline/locale/pt-pt/NewsKeyword.voc
+++ b/ocp_pipeline/locale/pt-pt/NewsKeyword.voc
@@ -1,1 +1,3 @@
-noticias
+noticiário
+notícias
+telejornal

--- a/ocp_pipeline/locale/pt-pt/play.intent
+++ b/ocp_pipeline/locale/pt-pt/play.intent
@@ -1,2 +1,2 @@
-(Procura|pesquisa) {query} multimédia
-(Toca|reproduz|põe a dar) {query}
+(Procura[r]|pesquisa[r]) {query} multimédia
+(Toca[r]|reproduz[ir]|(põe|pôr) [a dar]) {query}

--- a/ocp_pipeline/opm.py
+++ b/ocp_pipeline/opm.py
@@ -711,19 +711,7 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         valid_labels = valid_labels or [m for m, s in self.media2skill.items() if s] or list(MediaType)
         # simplistic approach via voc_match, works anywhere
         # and it's easy to localize, but isn't very accurate
-        if MediaType.MUSIC in valid_labels and self.voc_match(query, "MusicKeyword", lang=lang):
-            # NOTE - before movie to handle "{movie_name} soundtrack"
-            return MediaType.MUSIC, 0.6
-        elif any([s in valid_labels for s in [MediaType.MOVIE, MediaType.SHORT_FILM, MediaType.SILENT_MOVIE, MediaType.BLACK_WHITE_MOVIE]]) and \
-                self.voc_match(query, "MovieKeyword", lang=lang):
-            if MediaType.SHORT_FILM in valid_labels and self.voc_match(query, "ShortKeyword", lang=lang):
-                return MediaType.SHORT_FILM, 0.7
-            elif MediaType.SILENT_MOVIE in valid_labels and self.voc_match(query, "SilentKeyword", lang=lang):
-                return MediaType.SILENT_MOVIE, 0.7
-            elif MediaType.BLACK_WHITE_MOVIE in valid_labels and self.voc_match(query, "BWKeyword", lang=lang):
-                return MediaType.BLACK_WHITE_MOVIE, 0.7
-            return MediaType.MOVIE, 0.6
-        elif MediaType.DOCUMENTARY in valid_labels and self.voc_match(query, "DocumentaryKeyword", lang=lang):
+        if MediaType.DOCUMENTARY in valid_labels and self.voc_match(query, "DocumentaryKeyword", lang=lang):
             return MediaType.DOCUMENTARY, 0.6
         elif MediaType.AUDIOBOOK in valid_labels and self.voc_match(query, "AudioBookKeyword", lang=lang):
             return MediaType.AUDIOBOOK, 0.6
@@ -735,15 +723,27 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             return MediaType.CARTOON, 0.6
         elif MediaType.PODCAST in valid_labels and self.voc_match(query, "PodcastKeyword", lang=lang):
             return MediaType.PODCAST, 0.6
-        elif MediaType.TV in valid_labels and self.voc_match(query, "TVKeyword", lang=lang):
-            return MediaType.TV, 0.6
-        elif MediaType.VIDEO_EPISODES in valid_labels and self.voc_match(query, "SeriesKeyword", lang=lang):
-            return MediaType.VIDEO_EPISODES, 0.6
         elif MediaType.RADIO_THEATRE in valid_labels and self.voc_match(query, "AudioDramaKeyword", lang=lang):
             # NOTE - before "radio" to allow "radio theatre"
             return MediaType.RADIO_THEATRE, 0.6
         elif MediaType.RADIO in valid_labels and self.voc_match(query, "RadioKeyword", lang=lang):
             return MediaType.RADIO, 0.6
+        elif MediaType.MUSIC in valid_labels and self.voc_match(query, "MusicKeyword", lang=lang):
+            # NOTE - before movie to handle "{movie_name} soundtrack"
+            return MediaType.MUSIC, 0.6
+        elif MediaType.TV in valid_labels and self.voc_match(query, "TVKeyword", lang=lang):
+            return MediaType.TV, 0.6
+        elif MediaType.VIDEO_EPISODES in valid_labels and self.voc_match(query, "SeriesKeyword", lang=lang):
+            return MediaType.VIDEO_EPISODES, 0.6
+        elif any([s in valid_labels for s in [MediaType.MOVIE, MediaType.SHORT_FILM, MediaType.SILENT_MOVIE, MediaType.BLACK_WHITE_MOVIE]]) and \
+                self.voc_match(query, "MovieKeyword", lang=lang):
+            if MediaType.SHORT_FILM in valid_labels and self.voc_match(query, "ShortKeyword", lang=lang):
+                return MediaType.SHORT_FILM, 0.7
+            elif MediaType.SILENT_MOVIE in valid_labels and self.voc_match(query, "SilentKeyword", lang=lang):
+                return MediaType.SILENT_MOVIE, 0.7
+            elif MediaType.BLACK_WHITE_MOVIE in valid_labels and self.voc_match(query, "BWKeyword", lang=lang):
+                return MediaType.BLACK_WHITE_MOVIE, 0.7
+            return MediaType.MOVIE, 0.6
         elif MediaType.VISUAL_STORY in valid_labels and self.voc_match(query, "ComicBookKeyword", lang=lang):
             return MediaType.VISUAL_STORY, 0.4
         elif MediaType.GAME in valid_labels and self.voc_match(query, "GameKeyword", lang=lang):

--- a/scripts/sync_translations.py
+++ b/scripts/sync_translations.py
@@ -21,7 +21,7 @@ for lang in os.listdir(tx):
             data = json.load(f)
         for fid, samples in data.items():
             if samples:
-                samples = [s for s in samples if s]  # s may be None
+                samples = [s for s in samples if s and s != "[UNUSED]"]  # s may be None
                 with open(f"{locale}/{lang.lower()}/{fid}", "w") as f:
                     f.write("\n".join(sorted(samples)))
 
@@ -30,7 +30,7 @@ for lang in os.listdir(tx):
             data = json.load(f)
         for fid, samples in data.items():
             if samples:
-                samples = [s for s in samples if s]  # s may be None
+                samples = [s for s in samples if s and s != "[UNUSED]"]  # s may be None
                 with open(f"{locale}/{lang.lower()}/{fid}", "w") as f:
                     f.write("\n".join(sorted(samples)))
 
@@ -39,7 +39,7 @@ for lang in os.listdir(tx):
             data = json.load(f)
         for fid, samples in data.items():
             if samples:
-                samples = [s for s in samples if s]  # s may be None
+                samples = [s for s in samples if s and s != "[UNUSED]"]  # s may be None
                 with open(f"{locale}/{lang.lower()}/{fid}", "w") as f:
                     f.write("\n".join(sorted(samples)))
 
@@ -48,7 +48,7 @@ for lang in os.listdir(tx):
             data = json.load(f)
         for fid, samples in data.items():
             if samples:
-                samples = [s for s in samples if s]  # s may be None
+                samples = [s for s in samples if s and s != "[UNUSED]"]  # s may be None
                 with open(f"{locale}/{lang.lower()}/{fid}", "w") as f:
                     f.write("\n".join(sorted(samples)))
 

--- a/translations/pt-pt/intents.json
+++ b/translations/pt-pt/intents.json
@@ -1,7 +1,7 @@
 {
   "play.intent": [
-    "(Toca|reproduz|põe a dar) {query}",
-    "(Procura|pesquisa) {query} multimédia"
+    "(Toca[r]|reproduz[ir]|(põe|pôr) [a dar]) {query}",
+    "(Procura[r]|pesquisa[r]) {query} multimédia"
   ],
   "like_song.intent": [
     "Eu gosto (disto|deste|desta|disso)",

--- a/translations/pt-pt/vocabs.json
+++ b/translations/pt-pt/vocabs.json
@@ -31,7 +31,9 @@
     "(apenas|só) som"
   ],
   "NewsKeyword.voc": [
-    "noticias"
+    "notícias",
+    "noticiário",
+    "telejornal"
   ],
   "GameKeyword.voc": [
     "jogo"


### PR DESCRIPTION
invalid string "[UNUSED]"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization Updates**
	- Cleaned up unused vocabulary entries in Italian and Portuguese locale files
	- Updated Portuguese news-related keywords with more precise terms
	- Enhanced intent recognition patterns for Portuguese language commands

- **Vocabulary Improvements**
	- Removed `[UNUSED]` markers from multiple vocabulary files
	- Added more specific news-related terms in Portuguese translations

- **Intent Recognition**
	- Improved flexibility of Portuguese language command patterns
	- Added optional variations to search and playback commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->