### PR TITLE
chore(ovos-ocp-pipeline-plugin): allow ovos-workshop<9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ovos-workshop>=8.0.0,<8.1.0
+ovos-workshop>=8.0.0,<9.0.0
 ovos-utils>=0.3.5,<1.0.0
 ovos-plugin-manager>=1.0.0,<3.0.0
 ahocorasick-ner>=0.1.1,<1.0.0


### PR DESCRIPTION
Update ovos-workshop dependency upper bound to <9.0.0