### PR TITLE
feat!: mediavocab-native classification via ovos-media-classifier

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -12,5 +12,11 @@ jobs:
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       system_deps: 'swig'
-      pre_install_pip: '-r test/requirements.txt'
+      # mediavocab 1.0 and the MediaProvider plugin type are not yet on PyPI;
+      # install them from git before the package build/install. Drop these once
+      # both are published.
+      pre_install_pip: >-
+        ovos-plugin-manager@git+https://github.com/OpenVoiceOS/ovos-plugin-manager@feat/media-provider-plugin-type
+        mediavocab@git+https://github.com/TigreGotico/mediavocab@feat/audit-2026-05-core
+        -r test/requirements.txt
       test_path: 'test'

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -12,11 +12,12 @@ jobs:
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       system_deps: 'swig'
-      # mediavocab 1.0 and the MediaProvider plugin type are not yet on PyPI;
-      # install them from git before the package build/install. Drop these once
-      # both are published.
+      # mediavocab 1.0, the MediaProvider plugin type and ovos-media-classifier
+      # are not yet on PyPI; install them from git before the package
+      # build/install. Drop these once all are published.
       pre_install_pip: >-
         ovos-plugin-manager@git+https://github.com/OpenVoiceOS/ovos-plugin-manager@feat/media-provider-plugin-type
         mediavocab@git+https://github.com/TigreGotico/mediavocab@feat/audit-2026-05-core
+        ovos-media-classifier@git+https://github.com/OpenVoiceOS/ovos-media-classifier@dev
         -r test/requirements.txt
       test_path: 'test'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,5 +13,10 @@ jobs:
       python_version: '3.11'
       coverage_source: 'ocp_pipeline'
       test_path: 'test'
+      # mediavocab 1.0 and the MediaProvider plugin type are not yet on PyPI;
+      # install them from git before the package install. Drop once published.
+      pre_install_pip: >-
+        ovos-plugin-manager@git+https://github.com/OpenVoiceOS/ovos-plugin-manager@feat/media-provider-plugin-type
+        mediavocab@git+https://github.com/TigreGotico/mediavocab@feat/audit-2026-05-core
       install_extras: '-r test/requirements.txt'
       min_coverage: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,10 +13,12 @@ jobs:
       python_version: '3.11'
       coverage_source: 'ocp_pipeline'
       test_path: 'test'
-      # mediavocab 1.0 and the MediaProvider plugin type are not yet on PyPI;
-      # install them from git before the package install. Drop once published.
+      # mediavocab 1.0, the MediaProvider plugin type and ovos-media-classifier
+      # are not yet on PyPI; install them from git before the package install.
+      # Drop once all are published.
       pre_install_pip: >-
         ovos-plugin-manager@git+https://github.com/OpenVoiceOS/ovos-plugin-manager@feat/media-provider-plugin-type
         mediavocab@git+https://github.com/TigreGotico/mediavocab@feat/audit-2026-05-core
+        ovos-media-classifier@git+https://github.com/OpenVoiceOS/ovos-media-classifier@dev
       install_extras: '-r test/requirements.txt'
       min_coverage: 0

--- a/ocp_pipeline/bridge.py
+++ b/ocp_pipeline/bridge.py
@@ -1,92 +1,34 @@
-"""Bridge between in-process ``MediaProvider`` plugins and the OCP pipeline.
+"""Seam between in-process ``MediaProvider`` plugins and the OCP pipeline.
 
 ``MediaProvider`` plugins (``opm.media.provider``) speak the *mediavocab*
 catalog model: they consume a :class:`mediavocab.Signals` query and return
-:class:`mediavocab.Release` candidates. The rest of the OCP pipeline speaks the
-``ovos_utils.ocp`` playback model (``MediaEntry`` dicts / ``MediaType`` /
-``PlaybackType``).
+:class:`mediavocab.Release` candidates. The pipeline is now *mediavocab-native*
+too — it classifies and routes on :class:`mediavocab.MediaType` directly, so
+there is no media-type taxonomy translation here anymore.
 
-This module is the seam between the two:
-
-* :func:`media_type_to_signals` builds a ``Signals`` query from the pipeline's
-  classified ``ovos_utils.ocp.MediaType`` + text query, mapping the playback
-  taxonomy across to mediavocab's ``MediaType``.
-* :func:`release_to_ocp_result` maps a ``Release`` back into the OCP playback
-  result dict the pipeline already emits and ranks.
-
-Two distinct ``PlaybackType`` enums are involved and are mapped explicitly:
+The only thing this module still maps is the **playback backend selector**:
 
 * ``mediavocab.taxonomy.PlaybackType`` — *routing* (audio/video/paged/
-  interactive), describes how a work is consumed.
+  interactive), describes how a work is consumed. This is part of the catalog
+  model and is mediavocab's own taxonomy.
 * ``ovos_utils.ocp.PlaybackType`` — *backend selector* (AUDIO/VIDEO/SKILL/
-  WEBVIEW/…), tells OCP which player backend to hand the track to.
+  WEBVIEW/…), tells OCP which player backend to hand the track to. This is part
+  of the ``MediaEntry`` container structure, not the media-type taxonomy, so it
+  stays and is derived from the routing playback type.
 """
 from typing import Optional
 
-from ovos_utils.ocp import MediaType as OCPMediaType
 from ovos_utils.ocp import PlaybackType as OCPPlaybackType
 
 import mediavocab
-from mediavocab import MediaType as MVMediaType
+from mediavocab import MediaType
 from mediavocab import Release, Signals
 from mediavocab.taxonomy import PlaybackType as MVPlaybackType
 
 
-# ovos_utils.ocp.MediaType  ->  mediavocab.MediaType
-# Only the playback taxonomy the providers actually route on; anything not
-# listed (or GENERIC) is left as a typeless query so providers self-select via
-# their own three-axis gate.
-_OCP_TO_MV_MEDIA = {
-    OCPMediaType.MUSIC: MVMediaType.MUSIC,
-    OCPMediaType.AUDIO: MVMediaType.MUSIC,
-    OCPMediaType.PODCAST: MVMediaType.PODCAST,
-    OCPMediaType.AUDIOBOOK: MVMediaType.AUDIOBOOK,
-    OCPMediaType.RADIO: MVMediaType.RADIO,
-    OCPMediaType.RADIO_THEATRE: MVMediaType.AUDIO_DRAMA,
-    OCPMediaType.ADULT_AUDIO: MVMediaType.MUSIC,
-    OCPMediaType.ASMR: MVMediaType.PROCEDURAL_AMBIENT,
-    OCPMediaType.MOVIE: MVMediaType.MOVIE,
-    OCPMediaType.SILENT_MOVIE: MVMediaType.MOVIE,
-    OCPMediaType.BLACK_WHITE_MOVIE: MVMediaType.MOVIE,
-    OCPMediaType.SHORT_FILM: MVMediaType.SHORT_FILM,
-    OCPMediaType.TV: MVMediaType.TV,
-    OCPMediaType.VIDEO_EPISODES: MVMediaType.EPISODIC_SERIES,
-    OCPMediaType.CARTOON: MVMediaType.EPISODIC_SERIES,
-    OCPMediaType.ANIME: MVMediaType.EPISODIC_SERIES,
-    OCPMediaType.DOCUMENTARY: MVMediaType.MOVIE,
-    OCPMediaType.VIDEO: MVMediaType.MOVIE,
-    OCPMediaType.ADULT: MVMediaType.MOVIE,
-    OCPMediaType.HENTAI: MVMediaType.EPISODIC_SERIES,
-    OCPMediaType.GAME: MVMediaType.GAME,
-    OCPMediaType.VISUAL_STORY: MVMediaType.COMIC,
-    OCPMediaType.NEWS: MVMediaType.RADIO,
-}
-
-# reverse direction: mediavocab.MediaType -> ovos_utils.ocp.MediaType, used when
-# a Release comes back so the pipeline can keep filtering/ranking on its own
-# taxonomy. Picks the closest OCP label.
-_MV_TO_OCP_MEDIA = {
-    MVMediaType.MOVIE: OCPMediaType.MOVIE,
-    MVMediaType.SHORT_FILM: OCPMediaType.SHORT_FILM,
-    MVMediaType.EPISODIC_SERIES: OCPMediaType.VIDEO_EPISODES,
-    MVMediaType.TV: OCPMediaType.TV,
-    MVMediaType.MUSIC: OCPMediaType.MUSIC,
-    MVMediaType.MUSIC_VIDEO: OCPMediaType.VIDEO,
-    MVMediaType.PODCAST: OCPMediaType.PODCAST,
-    MVMediaType.AUDIOBOOK: OCPMediaType.AUDIOBOOK,
-    MVMediaType.AUDIO_DRAMA: OCPMediaType.RADIO_THEATRE,
-    MVMediaType.RADIO: OCPMediaType.RADIO,
-    MVMediaType.BOOK: OCPMediaType.AUDIOBOOK,
-    MVMediaType.COMIC: OCPMediaType.VISUAL_STORY,
-    MVMediaType.GAME: OCPMediaType.GAME,
-    MVMediaType.INTERACTIVE_FICTION: OCPMediaType.GAME,
-    MVMediaType.SOUND_EFFECT: OCPMediaType.AUDIO,
-    MVMediaType.PROCEDURAL_AMBIENT: OCPMediaType.ASMR,
-    MVMediaType.PLAYLIST: OCPMediaType.AUDIO,
-    MVMediaType.GENERIC: OCPMediaType.GENERIC,
-}
-
-# mediavocab routing taxonomy -> ovos_utils.ocp backend selector
+# mediavocab routing taxonomy -> ovos_utils.ocp backend selector.
+# This is NOT a media-type bridge: it maps mediavocab's playback routing onto
+# the OCP MediaEntry backend selector (which player to hand the track to).
 _MV_PLAYBACK_TO_OCP = {
     MVPlaybackType.AUDIO: OCPPlaybackType.AUDIO,
     MVPlaybackType.VIDEO: OCPPlaybackType.VIDEO,
@@ -96,39 +38,27 @@ _MV_PLAYBACK_TO_OCP = {
 }
 
 
-def ocp_media_type_to_mediavocab(media_type: OCPMediaType) -> Optional[MVMediaType]:
-    """Map an ``ovos_utils.ocp.MediaType`` to the closest ``mediavocab.MediaType``.
-
-    Returns ``None`` for ``GENERIC`` (and anything unmapped) so the query stays
-    typeless and providers self-select via their own routing gate.
-    """
-    if media_type == OCPMediaType.GENERIC:
-        return None
-    return _OCP_TO_MV_MEDIA.get(media_type)
-
-
-def mediavocab_media_type_to_ocp(media_type: MVMediaType) -> OCPMediaType:
-    """Map a ``mediavocab.MediaType`` back to the closest ``ovos_utils.ocp.MediaType``."""
-    return _MV_TO_OCP_MEDIA.get(media_type, OCPMediaType.GENERIC)
-
-
 def mediavocab_playback_to_ocp(pb: MVPlaybackType) -> OCPPlaybackType:
     """Map a ``mediavocab.taxonomy.PlaybackType`` (routing) to an
-    ``ovos_utils.ocp.PlaybackType`` (backend selector)."""
+    ``ovos_utils.ocp.PlaybackType`` (``MediaEntry`` backend selector)."""
     return _MV_PLAYBACK_TO_OCP.get(pb, OCPPlaybackType.UNDEFINED)
 
 
-def media_type_to_signals(media_type: OCPMediaType, query: str,
+def media_type_to_signals(media_type: MediaType, query: str,
                           artist: Optional[str] = None) -> Signals:
     """Build a query-role :class:`mediavocab.Signals` from the pipeline's
-    classified media type and free-text query."""
-    medium = ocp_media_type_to_mediavocab(media_type)
+    classified :class:`mediavocab.MediaType` and free-text query.
+
+    ``GENERIC`` (and the ``NOT_MEDIA``/``CONTROL`` sentinels) stay typeless so
+    providers self-select via their own three-axis routing gate.
+    """
     kwargs = {"title": query or None}
     if artist:
         kwargs["artist"] = artist
-    if medium is not None:
-        kwargs["medium"] = medium
-        kwargs["playback_type"] = mediavocab.infer_playback_type(medium)
+    if media_type not in (None, MediaType.GENERIC,
+                          MediaType.NOT_MEDIA, MediaType.CONTROL):
+        kwargs["medium"] = media_type
+        kwargs["playback_type"] = mediavocab.infer_playback_type(media_type)
     return Signals.as_query(**kwargs)
 
 
@@ -148,14 +78,18 @@ def release_to_ocp_result(release: Release, provider_id: str) -> dict:
     """Map a :class:`mediavocab.Release` to the OCP playback result dict the
     pipeline normalizes, ranks and plays.
 
+    The result's ``media_type`` is the release's :class:`mediavocab.MediaType`
+    directly (the pipeline is mediavocab-native). Only ``playback`` is derived,
+    mapping mediavocab's routing onto the OCP ``MediaEntry`` backend selector.
+
     @param release: the catalog candidate returned by a provider.
     @param provider_id: registry name of the provider; becomes ``skill_id``.
-    @return: a dict in the ``ovos_utils.ocp`` ``MediaEntry`` shape.
+    @return: a dict in the ``ovos_utils.ocp`` ``MediaEntry`` shape, carrying a
+             ``mediavocab.MediaType`` in ``media_type``.
     """
     work = release.work
-    mv_media = work.media_type
-    ocp_media = mediavocab_media_type_to_ocp(mv_media)
-    playback = mediavocab_playback_to_ocp(mediavocab.infer_playback_type(mv_media))
+    media_type = work.media_type
+    playback = mediavocab_playback_to_ocp(mediavocab.infer_playback_type(media_type))
 
     # match_confidence: mediavocab is 0.0..1.0 float, OCP MediaEntry is 0..100 int
     conf = release.match_confidence or 0.0
@@ -167,7 +101,7 @@ def release_to_ocp_result(release: Release, provider_id: str) -> dict:
         "image": release.image,
         "artist": _first_credit_name(release),
         "length": work.runtime or 0,
-        "media_type": ocp_media,
+        "media_type": media_type,
         "playback": playback,
         "match_confidence": match_conf,
         "skill_id": provider_id,

--- a/ocp_pipeline/bridge.py
+++ b/ocp_pipeline/bridge.py
@@ -1,0 +1,175 @@
+"""Bridge between in-process ``MediaProvider`` plugins and the OCP pipeline.
+
+``MediaProvider`` plugins (``opm.media.provider``) speak the *mediavocab*
+catalog model: they consume a :class:`mediavocab.Signals` query and return
+:class:`mediavocab.Release` candidates. The rest of the OCP pipeline speaks the
+``ovos_utils.ocp`` playback model (``MediaEntry`` dicts / ``MediaType`` /
+``PlaybackType``).
+
+This module is the seam between the two:
+
+* :func:`media_type_to_signals` builds a ``Signals`` query from the pipeline's
+  classified ``ovos_utils.ocp.MediaType`` + text query, mapping the playback
+  taxonomy across to mediavocab's ``MediaType``.
+* :func:`release_to_ocp_result` maps a ``Release`` back into the OCP playback
+  result dict the pipeline already emits and ranks.
+
+Two distinct ``PlaybackType`` enums are involved and are mapped explicitly:
+
+* ``mediavocab.taxonomy.PlaybackType`` — *routing* (audio/video/paged/
+  interactive), describes how a work is consumed.
+* ``ovos_utils.ocp.PlaybackType`` — *backend selector* (AUDIO/VIDEO/SKILL/
+  WEBVIEW/…), tells OCP which player backend to hand the track to.
+"""
+from typing import Optional
+
+from ovos_utils.ocp import MediaType as OCPMediaType
+from ovos_utils.ocp import PlaybackType as OCPPlaybackType
+
+import mediavocab
+from mediavocab import MediaType as MVMediaType
+from mediavocab import Release, Signals
+from mediavocab.taxonomy import PlaybackType as MVPlaybackType
+
+
+# ovos_utils.ocp.MediaType  ->  mediavocab.MediaType
+# Only the playback taxonomy the providers actually route on; anything not
+# listed (or GENERIC) is left as a typeless query so providers self-select via
+# their own three-axis gate.
+_OCP_TO_MV_MEDIA = {
+    OCPMediaType.MUSIC: MVMediaType.MUSIC,
+    OCPMediaType.AUDIO: MVMediaType.MUSIC,
+    OCPMediaType.PODCAST: MVMediaType.PODCAST,
+    OCPMediaType.AUDIOBOOK: MVMediaType.AUDIOBOOK,
+    OCPMediaType.RADIO: MVMediaType.RADIO,
+    OCPMediaType.RADIO_THEATRE: MVMediaType.AUDIO_DRAMA,
+    OCPMediaType.ADULT_AUDIO: MVMediaType.MUSIC,
+    OCPMediaType.ASMR: MVMediaType.PROCEDURAL_AMBIENT,
+    OCPMediaType.MOVIE: MVMediaType.MOVIE,
+    OCPMediaType.SILENT_MOVIE: MVMediaType.MOVIE,
+    OCPMediaType.BLACK_WHITE_MOVIE: MVMediaType.MOVIE,
+    OCPMediaType.SHORT_FILM: MVMediaType.SHORT_FILM,
+    OCPMediaType.TV: MVMediaType.TV,
+    OCPMediaType.VIDEO_EPISODES: MVMediaType.EPISODIC_SERIES,
+    OCPMediaType.CARTOON: MVMediaType.EPISODIC_SERIES,
+    OCPMediaType.ANIME: MVMediaType.EPISODIC_SERIES,
+    OCPMediaType.DOCUMENTARY: MVMediaType.MOVIE,
+    OCPMediaType.VIDEO: MVMediaType.MOVIE,
+    OCPMediaType.ADULT: MVMediaType.MOVIE,
+    OCPMediaType.HENTAI: MVMediaType.EPISODIC_SERIES,
+    OCPMediaType.GAME: MVMediaType.GAME,
+    OCPMediaType.VISUAL_STORY: MVMediaType.COMIC,
+    OCPMediaType.NEWS: MVMediaType.RADIO,
+}
+
+# reverse direction: mediavocab.MediaType -> ovos_utils.ocp.MediaType, used when
+# a Release comes back so the pipeline can keep filtering/ranking on its own
+# taxonomy. Picks the closest OCP label.
+_MV_TO_OCP_MEDIA = {
+    MVMediaType.MOVIE: OCPMediaType.MOVIE,
+    MVMediaType.SHORT_FILM: OCPMediaType.SHORT_FILM,
+    MVMediaType.EPISODIC_SERIES: OCPMediaType.VIDEO_EPISODES,
+    MVMediaType.TV: OCPMediaType.TV,
+    MVMediaType.MUSIC: OCPMediaType.MUSIC,
+    MVMediaType.MUSIC_VIDEO: OCPMediaType.VIDEO,
+    MVMediaType.PODCAST: OCPMediaType.PODCAST,
+    MVMediaType.AUDIOBOOK: OCPMediaType.AUDIOBOOK,
+    MVMediaType.AUDIO_DRAMA: OCPMediaType.RADIO_THEATRE,
+    MVMediaType.RADIO: OCPMediaType.RADIO,
+    MVMediaType.BOOK: OCPMediaType.AUDIOBOOK,
+    MVMediaType.COMIC: OCPMediaType.VISUAL_STORY,
+    MVMediaType.GAME: OCPMediaType.GAME,
+    MVMediaType.INTERACTIVE_FICTION: OCPMediaType.GAME,
+    MVMediaType.SOUND_EFFECT: OCPMediaType.AUDIO,
+    MVMediaType.PROCEDURAL_AMBIENT: OCPMediaType.ASMR,
+    MVMediaType.PLAYLIST: OCPMediaType.AUDIO,
+    MVMediaType.GENERIC: OCPMediaType.GENERIC,
+}
+
+# mediavocab routing taxonomy -> ovos_utils.ocp backend selector
+_MV_PLAYBACK_TO_OCP = {
+    MVPlaybackType.AUDIO: OCPPlaybackType.AUDIO,
+    MVPlaybackType.VIDEO: OCPPlaybackType.VIDEO,
+    MVPlaybackType.INTERACTIVE: OCPPlaybackType.SKILL,
+    MVPlaybackType.PAGED: OCPPlaybackType.WEBVIEW,
+    MVPlaybackType.UNKNOWN: OCPPlaybackType.UNDEFINED,
+}
+
+
+def ocp_media_type_to_mediavocab(media_type: OCPMediaType) -> Optional[MVMediaType]:
+    """Map an ``ovos_utils.ocp.MediaType`` to the closest ``mediavocab.MediaType``.
+
+    Returns ``None`` for ``GENERIC`` (and anything unmapped) so the query stays
+    typeless and providers self-select via their own routing gate.
+    """
+    if media_type == OCPMediaType.GENERIC:
+        return None
+    return _OCP_TO_MV_MEDIA.get(media_type)
+
+
+def mediavocab_media_type_to_ocp(media_type: MVMediaType) -> OCPMediaType:
+    """Map a ``mediavocab.MediaType`` back to the closest ``ovos_utils.ocp.MediaType``."""
+    return _MV_TO_OCP_MEDIA.get(media_type, OCPMediaType.GENERIC)
+
+
+def mediavocab_playback_to_ocp(pb: MVPlaybackType) -> OCPPlaybackType:
+    """Map a ``mediavocab.taxonomy.PlaybackType`` (routing) to an
+    ``ovos_utils.ocp.PlaybackType`` (backend selector)."""
+    return _MV_PLAYBACK_TO_OCP.get(pb, OCPPlaybackType.UNDEFINED)
+
+
+def media_type_to_signals(media_type: OCPMediaType, query: str,
+                          artist: Optional[str] = None) -> Signals:
+    """Build a query-role :class:`mediavocab.Signals` from the pipeline's
+    classified media type and free-text query."""
+    medium = ocp_media_type_to_mediavocab(media_type)
+    kwargs = {"title": query or None}
+    if artist:
+        kwargs["artist"] = artist
+    if medium is not None:
+        kwargs["medium"] = medium
+        kwargs["playback_type"] = mediavocab.infer_playback_type(medium)
+    return Signals.as_query(**kwargs)
+
+
+def _first_credit_name(release: Release) -> str:
+    """Best-effort 'artist' string: name of the first work credit."""
+    try:
+        credits = release.work.credits or []
+        if credits:
+            entity = credits[0].entity
+            return getattr(entity, "name", "") or ""
+    except Exception:
+        pass
+    return ""
+
+
+def release_to_ocp_result(release: Release, provider_id: str) -> dict:
+    """Map a :class:`mediavocab.Release` to the OCP playback result dict the
+    pipeline normalizes, ranks and plays.
+
+    @param release: the catalog candidate returned by a provider.
+    @param provider_id: registry name of the provider; becomes ``skill_id``.
+    @return: a dict in the ``ovos_utils.ocp`` ``MediaEntry`` shape.
+    """
+    work = release.work
+    mv_media = work.media_type
+    ocp_media = mediavocab_media_type_to_ocp(mv_media)
+    playback = mediavocab_playback_to_ocp(mediavocab.infer_playback_type(mv_media))
+
+    # match_confidence: mediavocab is 0.0..1.0 float, OCP MediaEntry is 0..100 int
+    conf = release.match_confidence or 0.0
+    match_conf = int(round(max(0.0, min(1.0, conf)) * 100))
+
+    result = {
+        "uri": release.uri,
+        "title": work.title,
+        "image": release.image,
+        "artist": _first_credit_name(release),
+        "length": work.runtime or 0,
+        "media_type": ocp_media,
+        "playback": playback,
+        "match_confidence": match_conf,
+        "skill_id": provider_id,
+    }
+    return result

--- a/ocp_pipeline/legacy.py
+++ b/ocp_pipeline/legacy.py
@@ -3,7 +3,8 @@ from typing import Tuple, Optional
 
 from ovos_bus_client.message import Message, dig_for_message
 from ovos_bus_client.util import wait_for_reply
-from ovos_utils.ocp import MediaType, PlaybackType, MediaEntry
+from ovos_utils.ocp import PlaybackType, MediaEntry
+from mediavocab import MediaType
 
 
 class LegacyCommonPlay:

--- a/ocp_pipeline/opm.py
+++ b/ocp_pipeline/opm.py
@@ -25,7 +25,10 @@ from ovos_workshop.app import OVOSAbstractApplication
 from ovos_utils.xdg_utils import xdg_data_home
 from ovos_config.meta import get_xdg_base
 from ahocorasick_ner import AhocorasickNER
+from ovos_media_classifier import load_media_classifier
 from ocp_pipeline.legacy import LegacyCommonPlay
+from ocp_pipeline.bridge import (ocp_media_type_to_mediavocab,
+                                 mediavocab_media_type_to_ocp)
 
 try:
     from ovos_plugin_manager.media_provider import load_media_providers
@@ -93,6 +96,13 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         }
         self.entity_csvs = self.config.get("entity_csvs", [])  # user defined keyword csv files
         self.ner = AhocorasickNER()
+
+        # media-type classification is delegated to ovos-media-classifier.
+        # The keyword backend is the extraction of this pipeline's own voc
+        # logic, so we hand it our voc_match (late-bound) and our locale .voc
+        # files. An external plugin can be selected via
+        # config["media_classifier_plugin"].
+        self._media_clf = load_media_classifier(self.config, voc_match_func=self._voc_match)
 
         # in-process MediaProvider plugins (opm.media.provider). These replace
         # the bus-broadcast OCP search skills: the pipeline gates them by routing
@@ -780,84 +790,59 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             self.ocp_api.stop(source_message=message)
 
     # NLP
-    def voc_match_media(self, query: str, lang: str, valid_labels: Optional[List[MediaType]] = None) -> Tuple[MediaType, float]:
-        lang = standardize_lang_tag(lang)
-        valid_labels = valid_labels or [m for m, s in self.media2skill.items() if s] or list(MediaType)
-        # simplistic approach via voc_match, works anywhere
-        # and it's easy to localize, but isn't very accurate
-        if MediaType.DOCUMENTARY in valid_labels and self.voc_match(query, "DocumentaryKeyword", lang=lang):
-            return MediaType.DOCUMENTARY, 0.6
-        elif MediaType.AUDIOBOOK in valid_labels and self.voc_match(query, "AudioBookKeyword", lang=lang):
-            return MediaType.AUDIOBOOK, 0.6
-        elif MediaType.NEWS in valid_labels and self.voc_match(query, "NewsKeyword", lang=lang):
-            return MediaType.NEWS, 0.6
-        elif MediaType.ANIME in valid_labels and  self.voc_match(query, "AnimeKeyword", lang=lang):
-            return MediaType.ANIME, 0.6
-        elif MediaType.CARTOON in valid_labels and self.voc_match(query, "CartoonKeyword", lang=lang):
-            return MediaType.CARTOON, 0.6
-        elif MediaType.PODCAST in valid_labels and self.voc_match(query, "PodcastKeyword", lang=lang):
-            return MediaType.PODCAST, 0.6
-        elif MediaType.RADIO_THEATRE in valid_labels and self.voc_match(query, "AudioDramaKeyword", lang=lang):
-            # NOTE - before "radio" to allow "radio theatre"
-            return MediaType.RADIO_THEATRE, 0.6
-        elif MediaType.RADIO in valid_labels and self.voc_match(query, "RadioKeyword", lang=lang):
-            return MediaType.RADIO, 0.6
-        elif MediaType.MUSIC in valid_labels and self.voc_match(query, "MusicKeyword", lang=lang):
-            # NOTE - before movie to handle "{movie_name} soundtrack"
-            return MediaType.MUSIC, 0.6
-        elif MediaType.TV in valid_labels and self.voc_match(query, "TVKeyword", lang=lang):
-            return MediaType.TV, 0.6
-        elif MediaType.VIDEO_EPISODES in valid_labels and self.voc_match(query, "SeriesKeyword", lang=lang):
-            return MediaType.VIDEO_EPISODES, 0.6
-        elif any([s in valid_labels for s in [MediaType.MOVIE, MediaType.SHORT_FILM, MediaType.SILENT_MOVIE, MediaType.BLACK_WHITE_MOVIE]]) and \
-                self.voc_match(query, "MovieKeyword", lang=lang):
-            if MediaType.SHORT_FILM in valid_labels and self.voc_match(query, "ShortKeyword", lang=lang):
-                return MediaType.SHORT_FILM, 0.7
-            elif MediaType.SILENT_MOVIE in valid_labels and self.voc_match(query, "SilentKeyword", lang=lang):
-                return MediaType.SILENT_MOVIE, 0.7
-            elif MediaType.BLACK_WHITE_MOVIE in valid_labels and self.voc_match(query, "BWKeyword", lang=lang):
-                return MediaType.BLACK_WHITE_MOVIE, 0.7
-            return MediaType.MOVIE, 0.6
-        elif MediaType.VISUAL_STORY in valid_labels and self.voc_match(query, "ComicBookKeyword", lang=lang):
-            return MediaType.VISUAL_STORY, 0.4
-        elif MediaType.GAME in valid_labels and self.voc_match(query, "GameKeyword", lang=lang):
-            return MediaType.GAME, 0.4
-        elif MediaType.AUDIO_DESCRIPTION in valid_labels and self.voc_match(query, "ADKeyword", lang=lang):
-            return MediaType.AUDIO_DESCRIPTION, 0.4
-        elif MediaType.ASMR in valid_labels and self.voc_match(query, "ASMRKeyword", lang=lang):
-            return MediaType.ASMR, 0.4
-        elif any([s in valid_labels for s in [MediaType.ADULT, MediaType.HENTAI, MediaType.ADULT_AUDIO]]) and self.voc_match(query, "AdultKeyword", lang=lang):
-            if MediaType.HENTAI in valid_labels and self.voc_match(query, "CartoonKeyword", lang=lang) or \
-                    self.voc_match(query, "AnimeKeyword", lang=lang) or \
-                    self.voc_match(query, "HentaiKeyword", lang=lang):
-                return MediaType.HENTAI, 0.4
-            elif MediaType.ADULT_AUDIO in valid_labels and  self.voc_match(query, "AudioKeyword", lang=lang) or \
-                    self.voc_match(query, "ASMRKeyword", lang=lang):
-                return MediaType.ADULT_AUDIO, 0.4
-            return MediaType.ADULT, 0.4
-        elif MediaType.HENTAI in valid_labels and self.voc_match(query, "HentaiKeyword", lang=lang):
-            return MediaType.HENTAI, 0.4
-        elif MediaType.VIDEO in valid_labels and self.voc_match(query, "VideoKeyword", lang=lang):
-            return MediaType.VIDEO, 0.4
-        elif MediaType.AUDIO in valid_labels and self.voc_match(query, "AudioKeyword", lang=lang):
-            return MediaType.AUDIO, 0.4
-        return MediaType.GENERIC, 0.0
+    def _voc_match(self, phrase: str, vocab_name: str, *, lang: str) -> bool:
+        """Late-bound ``(phrase, vocab_name, *, lang) -> bool`` matcher handed to
+        ``ovos-media-classifier``.
+
+        It defers to ``self.voc_match`` at call time (rather than binding it
+        once) so the classifier always uses the pipeline's current locale
+        ``.voc`` files. Classification itself lives in the package now; this
+        only exposes the pipeline's keyword matcher to it.
+        """
+        return self.voc_match(phrase, vocab_name, lang=lang)
+
+    @property
+    def media_clf(self):
+        """The media classifier, built lazily from the pipeline's voc_match.
+
+        Normally instantiated in ``__init__``; this also covers callers that
+        bypass ``__init__`` (e.g. tests via ``__new__``).
+        """
+        clf = getattr(self, "_media_clf", None)
+        if clf is None:
+            clf = self._media_clf = load_media_classifier(
+                getattr(self, "config", None), voc_match_func=self._voc_match)
+        return clf
 
     def classify_media(self, query: str, lang: str, valid_labels: Optional[List[MediaType]] = None) -> Tuple[MediaType, float]:
-        """ determine what media type is being requested """
+        """Determine what media type is being requested.
+
+        Delegates classification to ``ovos-media-classifier`` (whose keyword
+        backend is the extraction of this pipeline's own voc logic) and bridges
+        the result between the ``ovos_utils.ocp`` and ``mediavocab`` taxonomies.
+        """
         lang = standardize_lang_tag(lang)
         valid_labels = valid_labels or [m for m, s in self.media2skill.items() if s] or list(MediaType)
         LOG.debug(f"valid media types: {valid_labels}")
         if len(valid_labels) == 1:
             return valid_labels[0], 1.0
 
-        return self.voc_match_media(query, lang, valid_labels)
+        # ocp valid_labels -> mediavocab (drop GENERIC/unmapped)
+        mv_valid = [mv for mv in (ocp_media_type_to_mediavocab(m) for m in valid_labels)
+                    if mv is not None] or None
+        mv_type, conf = self.media_clf.classify(query, lang, mv_valid)
+        ocp_type = mediavocab_media_type_to_ocp(mv_type)
+        # the mediavocab<->ocp mapping is many-to-one, so re-apply the original
+        # ocp valid_labels filter; if the mapped type is excluded, fall back to
+        # GENERIC rather than returning a label the caller forbade.
+        if ocp_type not in valid_labels:
+            return MediaType.GENERIC, 0.0
+        return ocp_type, conf
 
     def is_ocp_query(self, query: str, lang: str) -> Tuple[bool, float]:
-        """ determine if a playback question is being asked"""
+        """Determine if a playback question is being asked."""
         lang = standardize_lang_tag(lang)
-        m, p = self.voc_match_media(query, lang)
-        return m != MediaType.GENERIC, p
+        return self.media_clf.is_ocp_query(query, lang)
 
     def _should_resume(self, phrase: str, lang: str, message: Optional[Message] = None) -> bool:
         """

--- a/ocp_pipeline/opm.py
+++ b/ocp_pipeline/opm.py
@@ -1,6 +1,7 @@
 import os
 import random
 import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from os.path import join, dirname
 from threading import RLock
@@ -25,6 +26,19 @@ from ovos_utils.xdg_utils import xdg_data_home
 from ovos_config.meta import get_xdg_base
 from ahocorasick_ner import AhocorasickNER
 from ocp_pipeline.legacy import LegacyCommonPlay
+
+try:
+    from ovos_plugin_manager.media_provider import load_media_providers
+    from ovos_plugin_manager.templates.media_provider import MediaProvider
+    from ocp_pipeline.bridge import media_type_to_signals, release_to_ocp_result
+    _HAS_MEDIA_PROVIDERS = True
+except ImportError:
+    # ovos-plugin-manager without the MediaProvider type / mediavocab missing.
+    # Provider dispatch silently degrades to the bus-only OCP-skill path.
+    load_media_providers = None
+    MediaProvider = None
+    media_type_to_signals = release_to_ocp_result = None
+    _HAS_MEDIA_PROVIDERS = False
 
 
 @dataclass
@@ -79,6 +93,13 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         }
         self.entity_csvs = self.config.get("entity_csvs", [])  # user defined keyword csv files
         self.ner = AhocorasickNER()
+
+        # in-process MediaProvider plugins (opm.media.provider). These replace
+        # the bus-broadcast OCP search skills: the pipeline gates them by routing
+        # and calls search() directly. The bus-skill path is kept alongside; both
+        # sources compete in the same normalize/rank/select_best flow.
+        self.media_providers: Dict[str, "MediaProvider"] = {}
+        self._load_media_providers()
 
         self.register_ocp_api_events()
         self.register_ocp_intents()
@@ -167,6 +188,29 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         self.add_event("ocp:like_song", self.handle_like_intent, is_intent=True)
         self.add_event("ocp:save_game", self.handle_save_intent, is_intent=True)
         self.add_event("ocp:load_game", self.handle_load_intent, is_intent=True)
+
+    def _load_media_providers(self):
+        """Discover and instantiate installed ``opm.media.provider`` plugins.
+
+        ``load_media_providers`` already filters by ``is_available()`` and the
+        per-provider ``enabled: false`` config gate. When the MediaProvider type
+        (ovos-plugin-manager) or mediavocab is unavailable, or no providers are
+        installed/enabled, ``self.media_providers`` stays empty and the pipeline
+        behaves exactly as the bus-only OCP-skill path.
+        """
+        if not _HAS_MEDIA_PROVIDERS:
+            LOG.debug("MediaProvider plugin type unavailable; "
+                      "using bus-only OCP search")
+            return
+        try:
+            cfg = self.config.get("media_providers", None)
+            self.media_providers = load_media_providers(cfg) or {}
+            if self.media_providers:
+                LOG.info(f"Loaded {len(self.media_providers)} MediaProvider "
+                         f"plugins: {list(self.media_providers)}")
+        except Exception:
+            LOG.exception("failed to load MediaProvider plugins")
+            self.media_providers = {}
 
     def update_player_proxy(self, player: OCPPlayerProxy):
         """remember OCP session state"""
@@ -954,6 +998,65 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
 
         return results
 
+    def _search_providers(self, phrase: str, media_type: MediaType,
+                          lang: str) -> RawResultsList:
+        """Dispatch the query to in-process MediaProvider plugins.
+
+        Builds a :class:`mediavocab.Signals` from the classified media type and
+        query, gates each provider with its three-axis ``matches()`` routing
+        test, then runs the surviving providers concurrently through a thread
+        pool calling ``search_safe`` (which never raises). Each returned
+        ``mediavocab.Release`` is bridged to the OCP playback result dict so it
+        can compete in the same normalize/rank/select_best flow as bus results.
+
+        Returns an empty list when no providers are installed/enabled.
+        """
+        if not self.media_providers:
+            return []
+
+        signals = media_type_to_signals(media_type, phrase)
+
+        # three-axis routing gate: skip providers that can't serve this query
+        targets = {}
+        for name, provider in self.media_providers.items():
+            try:
+                if provider.matches(signals):
+                    targets[name] = provider
+            except Exception:
+                LOG.exception(f"MediaProvider '{name}' routing gate failed")
+        if not targets:
+            LOG.debug("no MediaProvider matched the query routing")
+            return []
+
+        LOG.debug(f"dispatching to {len(targets)} MediaProviders: {list(targets)}")
+        min_timeout = self.config.get("min_timeout", 5)
+        max_timeout = self.config.get("max_timeout", 15)
+
+        results: RawResultsList = []
+        with ThreadPoolExecutor(max_workers=len(targets)) as executor:
+            futures = {
+                executor.submit(p.search_safe, signals, lang): name
+                for name, p in targets.items()
+            }
+            got_results = False
+            for fut in as_completed(futures, timeout=None):
+                name = futures[fut]
+                try:
+                    releases = fut.result(timeout=max_timeout) or []
+                except Exception:
+                    LOG.exception(f"MediaProvider '{name}' search failed")
+                    continue
+                if releases:
+                    got_results = True
+                for release in releases:
+                    try:
+                        results.append(release_to_ocp_result(release, name))
+                    except Exception:
+                        LOG.exception(f"failed to bridge result from '{name}'")
+        LOG.debug(f"MediaProviders returned {len(results)} results "
+                  f"(min_timeout={min_timeout}, max_timeout={max_timeout})")
+        return results
+
     def _search(self, phrase: str, media_type: MediaType, lang: str,
                 skills: Optional[List[str]] = None,
                 message: Optional[Message] = None) -> list:
@@ -968,6 +1071,13 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                                      skills=skills,
                                      message=message):
             results += r["results"]
+
+        # in-process MediaProvider plugins are an additional source; their
+        # bridged results compete with the bus results by match_confidence.
+        # Skill-targeted searches (user named a specific OCP skill) stay
+        # bus-only.
+        if not skills:
+            results += self._search_providers(phrase, media_type, lang)
 
         results = self.normalize_results(results)
 

--- a/ocp_pipeline/opm.py
+++ b/ocp_pipeline/opm.py
@@ -19,16 +19,15 @@ from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch, Confidenc
 from ovos_utils.lang import standardize_lang_tag, get_language_dir
 from ovos_utils.log import LOG, deprecated, log_deprecation
 from ovos_utils.fakebus import FakeBus
-from ovos_utils.ocp import MediaType, PlaybackType, PlaybackMode, PlayerState, OCP_ID, \
+from ovos_utils.ocp import PlaybackType, PlaybackMode, PlayerState, OCP_ID, \
     MediaEntry, Playlist, MediaState, TrackState, dict2entry, PluginStream
 from ovos_workshop.app import OVOSAbstractApplication
 from ovos_utils.xdg_utils import xdg_data_home
 from ovos_config.meta import get_xdg_base
 from ahocorasick_ner import AhocorasickNER
 from ovos_media_classifier import load_media_classifier
+from mediavocab import MediaType
 from ocp_pipeline.legacy import LegacyCommonPlay
-from ocp_pipeline.bridge import (ocp_media_type_to_mediavocab,
-                                 mediavocab_media_type_to_ocp)
 
 try:
     from ovos_plugin_manager.media_provider import load_media_providers
@@ -258,24 +257,18 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                 self.ner.add_word("music_streaming_service", a)
             if MediaType.MOVIE in media:
                 self.ner.add_word("movie_streaming_service", a)
-            # if MediaType.SILENT_MOVIE in media:
-            #    self.ner.add_word("silent_movie_streaming_service", a)
-            # if MediaType.BLACK_WHITE_MOVIE in media:
-            #    self.ner.add_word("bw_movie_streaming_service", a)
             if MediaType.SHORT_FILM in media:
                 self.ner.add_word("shorts_streaming_service", a)
             if MediaType.PODCAST in media:
                 self.ner.add_word("podcast_streaming_service", a)
             if MediaType.AUDIOBOOK in media:
                 self.ner.add_word("audiobook_streaming_service", a)
-            if MediaType.NEWS in media:
-                self.ner.add_word("news_provider", a)
             if MediaType.TV in media:
                 self.ner.add_word("tv_streaming_service", a)
             if MediaType.RADIO in media:
+                # mediavocab folds news/talk radio into RADIO
                 self.ner.add_word("radio_streaming_service", a)
-            if MediaType.ADULT in media:
-                self.ner.add_word("porn_streaming_service", a)
+                self.ner.add_word("news_provider", a)
 
     def handle_skill_keyword_register(self, message: Message):
         """
@@ -353,7 +346,11 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             player.media_state = MediaState(mstate)
             LOG.debug(f"Session: {player.session_id} MediaState: {player.media_state}")
         if mtype is not None:
-            player.media_type = MediaType(pstate)
+            try:
+                player.media_type = self._normalize_media_enum(mtype)
+            except Exception:
+                LOG.debug(f"unrecognized media_type in status update: {mtype}")
+                player.media_type = MediaType.GENERIC
             LOG.debug(f"Session: {player.session_id} MediaType: {player.media_type}")
         player = self._update_player_skill_id(player, message)
         self.update_player_proxy(player)
@@ -638,14 +635,29 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
 
     # intent handlers
     @staticmethod
-    def _normalize_media_enum(m: Union[int, MediaType]):
+    def _normalize_media_enum(m: Union[str, MediaType]) -> MediaType:
+        """Coerce a media-type token into a :class:`mediavocab.MediaType`.
+
+        Accepts a ``MediaType`` (passthrough), its string value (e.g.
+        ``"music"``) or its member name (e.g. ``"MUSIC"``). Anything else
+        (including the legacy ``ovos_utils.ocp`` integer ids that pre-mediavocab
+        skills emit) is not a valid mediavocab media type and raises -- callers
+        treat that as an untyped/GENERIC registration.
+        """
         if isinstance(m, MediaType):
             return m
-        # convert int to enum
-        for e in MediaType:
-            if e == m:
-                return e
-        raise ValueError(f"{m} is not a valid media type")
+        if isinstance(m, str):
+            # by value (mediavocab is a str-enum), e.g. "music"
+            try:
+                return MediaType(m)
+            except ValueError:
+                pass
+            # by member name, e.g. "MUSIC"
+            try:
+                return MediaType[m.upper()]
+            except KeyError:
+                pass
+        raise ValueError(f"{m!r} is not a valid mediavocab media type")
 
     def handle_save_intent(self, message: Message):
         skill_id = self.get_player(message).skill_id
@@ -814,30 +826,30 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                 getattr(self, "config", None), voc_match_func=self._voc_match)
         return clf
 
-    def classify_media(self, query: str, lang: str, valid_labels: Optional[List[MediaType]] = None) -> Tuple[MediaType, float]:
-        """Determine what media type is being requested.
+    def classify_media(self, query: str, lang: str,
+                       valid_labels: Optional[List[MediaType]] = None) -> Tuple[MediaType, float]:
+        """Determine what :class:`mediavocab.MediaType` is being requested.
 
         Delegates classification to ``ovos-media-classifier`` (whose keyword
-        backend is the extraction of this pipeline's own voc logic) and bridges
-        the result between the ``ovos_utils.ocp`` and ``mediavocab`` taxonomies.
+        backend is the extraction of this pipeline's own voc logic). The
+        classifier is mediavocab-native, so its result is returned directly --
+        there is no taxonomy translation. ``valid_labels`` are
+        ``mediavocab.MediaType`` and restrict the candidate set.
         """
         lang = standardize_lang_tag(lang)
-        valid_labels = valid_labels or [m for m, s in self.media2skill.items() if s] or list(MediaType)
+        valid_labels = valid_labels or [m for m, s in self.media2skill.items() if s] or None
         LOG.debug(f"valid media types: {valid_labels}")
-        if len(valid_labels) == 1:
+        if valid_labels and len(valid_labels) == 1:
             return valid_labels[0], 1.0
 
-        # ocp valid_labels -> mediavocab (drop GENERIC/unmapped)
-        mv_valid = [mv for mv in (ocp_media_type_to_mediavocab(m) for m in valid_labels)
-                    if mv is not None] or None
-        mv_type, conf = self.media_clf.classify(query, lang, mv_valid)
-        ocp_type = mediavocab_media_type_to_ocp(mv_type)
-        # the mediavocab<->ocp mapping is many-to-one, so re-apply the original
-        # ocp valid_labels filter; if the mapped type is excluded, fall back to
-        # GENERIC rather than returning a label the caller forbade.
-        if ocp_type not in valid_labels:
-            return MediaType.GENERIC, 0.0
-        return ocp_type, conf
+        # GENERIC (and the NOT_MEDIA/CONTROL sentinels) are never a useful
+        # restriction; drop them so the classifier can still pick a real type.
+        mv_valid = None
+        if valid_labels:
+            mv_valid = [m for m in valid_labels
+                        if m not in (MediaType.GENERIC, MediaType.NOT_MEDIA,
+                                     MediaType.CONTROL)] or None
+        return self.media_clf.classify(query, lang, mv_valid)
 
     def is_ocp_query(self, query: str, lang: str) -> Tuple[bool, float]:
         """Determine if a playback question is being asked."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "ovos-utils>=0.3.5,<1.0.0",
     "ovos-plugin-manager>=2.1.0,<3.0.0",
     "mediavocab>=1.0.0,<2.0.0",
+    "ovos-media-classifier>=0.0.1,<1.0.0",
     "ahocorasick-ner>=0.1.1,<1.0.0",
     "langcodes"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "ovos-workshop>=8.0.0,<9.0.0",
     "ovos-utils>=0.3.5,<1.0.0",
     "ovos-plugin-manager>=2.1.0,<3.0.0",
+    "mediavocab>=1.0.0,<2.0.0",
     "ahocorasick-ner>=0.1.1,<1.0.0",
     "langcodes"
 ]

--- a/test/test_media_classifier_e2e.py
+++ b/test/test_media_classifier_e2e.py
@@ -1,0 +1,92 @@
+"""End-to-end tests for media-type classification via ovos-media-classifier.
+
+These exercise the *real* classifier (not mocked) end to end: the pipeline
+hands its own ``voc_match`` + locale ``.voc`` files to
+``ovos-media-classifier``'s keyword backend (which is the extraction of the
+pipeline's former embedded voc logic), and the result is bridged from
+``mediavocab.MediaType`` back to ``ovos_utils.ocp.MediaType``.
+
+Two taxonomies are involved and converge here: e.g. ``anime``/``cartoon`` now
+classify through mediavocab ``EPISODIC_SERIES`` and surface as ocp
+``VIDEO_EPISODES``; ``documentary`` and ``news`` collapse onto ``MOVIE`` /
+``RADIO`` respectively. See ``ocp_pipeline.bridge`` for the exact mapping.
+"""
+import unittest
+
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import MediaType
+
+from ocp_pipeline.opm import OCPPipelineMatcher
+
+
+class TestMediaClassifierE2E(unittest.TestCase):
+    """Real classifier, real locale .voc files, real mediavocab<->ocp bridge."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ocp = OCPPipelineMatcher(bus=FakeBus())
+
+    def test_real_classifier_is_wired(self):
+        """The matcher delegates to a real ovos-media-classifier instance."""
+        from ovos_media_classifier.base import AbstractMediaClassifier
+        self.assertIsInstance(self.ocp.media_clf, AbstractMediaClassifier)
+
+    def test_classify_media_real_utterances(self):
+        """Real utterances classify to the expected ocp.MediaType after the
+        mediavocab -> ocp bridge."""
+        cases = {
+            # query                       -> expected ovos_utils.ocp.MediaType
+            "play some music": MediaType.MUSIC,
+            "watch a movie": MediaType.MOVIE,
+            "play a podcast": MediaType.PODCAST,
+            # taxonomy convergence: ANIME/CARTOON -> mediavocab EPISODIC_SERIES
+            # -> ocp VIDEO_EPISODES
+            "i want to watch an anime": MediaType.VIDEO_EPISODES,
+            "play a cartoon": MediaType.VIDEO_EPISODES,
+            # NEWS -> mediavocab RADIO -> ocp RADIO
+            "play the news": MediaType.RADIO,
+            # DOCUMENTARY -> mediavocab MOVIE -> ocp MOVIE
+            "show me a documentary": MediaType.MOVIE,
+        }
+        for query, expected in cases.items():
+            media, conf = self.ocp.classify_media(query, "en-US")
+            self.assertEqual(media, expected,
+                             f"{query!r} -> {media} (expected {expected})")
+            self.assertIsInstance(conf, float)
+            self.assertGreater(conf, 0.0)
+
+    def test_classify_media_no_keyword_is_generic(self):
+        """A bare artist name with no media keyword stays GENERIC."""
+        media, conf = self.ocp.classify_media("play metallica", "en-US")
+        self.assertEqual(media, MediaType.GENERIC)
+        self.assertEqual(conf, 0.0)
+
+    def test_classify_media_respects_valid_labels(self):
+        """A query whose mapped type is excluded by valid_labels -> GENERIC."""
+        # "play some music" maps to MUSIC, but MUSIC is not allowed here
+        media, _ = self.ocp.classify_media(
+            "play some music", "en-US", valid_labels=[MediaType.PODCAST])
+        self.assertNotEqual(media, MediaType.MUSIC)
+
+    def test_is_ocp_query_true_for_media(self):
+        for query in ("play some music", "watch a movie", "play a podcast",
+                      "i want to watch an anime", "play the news"):
+            is_ocp, _ = self.ocp.is_ocp_query(query, "en-US")
+            self.assertTrue(is_ocp, f"{query!r} should be an OCP query")
+
+    def test_is_ocp_query_false_for_non_media(self):
+        is_ocp, _ = self.ocp.is_ocp_query("what time is it", "en-US")
+        self.assertFalse(is_ocp)
+
+    def test_classification_extracted_from_pipeline(self):
+        """The embedded voc_match_media elif chain is gone; classification now
+        lives in the package. The pipeline keeps only the thin adapters."""
+        # the dead method must no longer exist on the matcher
+        self.assertFalse(hasattr(self.ocp, "voc_match_media"))
+        # the thin adapters remain and delegate to the package
+        self.assertTrue(hasattr(self.ocp, "classify_media"))
+        self.assertTrue(hasattr(self.ocp, "is_ocp_query"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_media_classifier_e2e.py
+++ b/test/test_media_classifier_e2e.py
@@ -3,24 +3,24 @@
 These exercise the *real* classifier (not mocked) end to end: the pipeline
 hands its own ``voc_match`` + locale ``.voc`` files to
 ``ovos-media-classifier``'s keyword backend (which is the extraction of the
-pipeline's former embedded voc logic), and the result is bridged from
-``mediavocab.MediaType`` back to ``ovos_utils.ocp.MediaType``.
+pipeline's former embedded voc logic), and the result -- a
+:class:`mediavocab.MediaType` -- is returned directly. The pipeline is
+mediavocab-native; there is no ``ovos_utils.ocp`` taxonomy translation.
 
-Two taxonomies are involved and converge here: e.g. ``anime``/``cartoon`` now
-classify through mediavocab ``EPISODIC_SERIES`` and surface as ocp
-``VIDEO_EPISODES``; ``documentary`` and ``news`` collapse onto ``MOVIE`` /
-``RADIO`` respectively. See ``ocp_pipeline.bridge`` for the exact mapping.
+Some legacy keyword buckets converge onto the mediavocab taxonomy: e.g.
+``anime``/``cartoon`` classify to ``EPISODIC_SERIES``; ``documentary`` collapses
+onto ``MOVIE``; ``news`` onto ``RADIO``.
 """
 import unittest
 
 from ovos_utils.fakebus import FakeBus
-from ovos_utils.ocp import MediaType
+from mediavocab import MediaType
 
 from ocp_pipeline.opm import OCPPipelineMatcher
 
 
 class TestMediaClassifierE2E(unittest.TestCase):
-    """Real classifier, real locale .voc files, real mediavocab<->ocp bridge."""
+    """Real classifier, real locale .voc files, mediavocab-native results."""
 
     @classmethod
     def setUpClass(cls):
@@ -32,26 +32,25 @@ class TestMediaClassifierE2E(unittest.TestCase):
         self.assertIsInstance(self.ocp.media_clf, AbstractMediaClassifier)
 
     def test_classify_media_real_utterances(self):
-        """Real utterances classify to the expected ocp.MediaType after the
-        mediavocab -> ocp bridge."""
+        """Real utterances classify to the expected mediavocab.MediaType."""
         cases = {
-            # query                       -> expected ovos_utils.ocp.MediaType
+            # query                       -> expected mediavocab.MediaType
             "play some music": MediaType.MUSIC,
             "watch a movie": MediaType.MOVIE,
             "play a podcast": MediaType.PODCAST,
-            # taxonomy convergence: ANIME/CARTOON -> mediavocab EPISODIC_SERIES
-            # -> ocp VIDEO_EPISODES
-            "i want to watch an anime": MediaType.VIDEO_EPISODES,
-            "play a cartoon": MediaType.VIDEO_EPISODES,
-            # NEWS -> mediavocab RADIO -> ocp RADIO
+            # ANIME/CARTOON -> mediavocab EPISODIC_SERIES
+            "i want to watch an anime": MediaType.EPISODIC_SERIES,
+            "play a cartoon": MediaType.EPISODIC_SERIES,
+            # NEWS -> mediavocab RADIO
             "play the news": MediaType.RADIO,
-            # DOCUMENTARY -> mediavocab MOVIE -> ocp MOVIE
+            # DOCUMENTARY -> mediavocab MOVIE
             "show me a documentary": MediaType.MOVIE,
         }
         for query, expected in cases.items():
             media, conf = self.ocp.classify_media(query, "en-US")
             self.assertEqual(media, expected,
                              f"{query!r} -> {media} (expected {expected})")
+            self.assertIsInstance(media, MediaType)
             self.assertIsInstance(conf, float)
             self.assertGreater(conf, 0.0)
 
@@ -62,7 +61,7 @@ class TestMediaClassifierE2E(unittest.TestCase):
         self.assertEqual(conf, 0.0)
 
     def test_classify_media_respects_valid_labels(self):
-        """A query whose mapped type is excluded by valid_labels -> GENERIC."""
+        """A query whose type is excluded by valid_labels is not returned."""
         # "play some music" maps to MUSIC, but MUSIC is not allowed here
         media, _ = self.ocp.classify_media(
             "play some music", "en-US", valid_labels=[MediaType.PODCAST])

--- a/test/test_media_providers.py
+++ b/test/test_media_providers.py
@@ -1,0 +1,236 @@
+"""Unit tests for in-process MediaProvider dispatch and the Release->OCP bridge.
+
+These use mock ``MediaProvider`` subclasses returning synthetic
+``mediavocab.Release`` objects, registered via a monkeypatched
+``load_media_providers``. They cover:
+
+* the three-axis routing gate (a provider that can't serve a query is skipped),
+* concurrent dispatch returning ranked results,
+* the ``Release`` -> OCP result bridge field mapping,
+* that bus-path behaviour is unchanged when no providers are installed.
+"""
+import unittest
+from typing import List, Set
+
+from mediavocab import MediaType as MVMediaType
+from mediavocab import EntityKind, Release, Signals, Work
+from mediavocab.models.entity import Credit, EntityRef
+from mediavocab.taxonomy import PlaybackType as MVPlaybackType
+
+from ovos_utils.ocp import MediaType as OCPMediaType
+from ovos_utils.ocp import PlaybackType as OCPPlaybackType
+
+from ocp_pipeline.bridge import (release_to_ocp_result, media_type_to_signals,
+                                 ocp_media_type_to_mediavocab,
+                                 mediavocab_media_type_to_ocp,
+                                 mediavocab_playback_to_ocp)
+from ocp_pipeline.opm import OCPPipelineMatcher
+
+try:
+    from ovos_plugin_manager.templates.media_provider import MediaProvider
+    HAS_MP = True
+except ImportError:
+    MediaProvider = object
+    HAS_MP = False
+
+
+def _make_release(title: str, media_type: MVMediaType, uri: str,
+                  conf: float, artist: str = "", runtime: float = 0) -> Release:
+    credits = []
+    if artist:
+        credits = [Credit(entity=EntityRef(name=artist, kind=EntityKind.GROUP),
+                          role="artist")]
+    work = Work(title=title, media_type=media_type, runtime=runtime,
+                credits=credits)
+    return Release(work=work, uri=uri, image=f"{title}.png",
+                   match_confidence=conf)
+
+
+if HAS_MP:
+    class MusicProvider(MediaProvider):
+        name = "mock.music"
+        media: Set[MVMediaType] = {MVMediaType.MUSIC}
+
+        def is_available(self) -> bool:
+            return True
+
+        def search(self, signals: Signals, lang: str = "en-us") -> List[Release]:
+            return [
+                _make_release("Black Album", MVMediaType.MUSIC,
+                              "https://music/black", 0.9, artist="Metallica",
+                              runtime=3600),
+                _make_release("Ride the Lightning", MVMediaType.MUSIC,
+                              "https://music/ride", 0.6, artist="Metallica"),
+            ]
+
+    class MovieProvider(MediaProvider):
+        name = "mock.movie"
+        media: Set[MVMediaType] = {MVMediaType.MOVIE}
+
+        def is_available(self) -> bool:
+            return True
+
+        def search(self, signals: Signals, lang: str = "en-us") -> List[Release]:
+            return [
+                _make_release("Some Movie", MVMediaType.MOVIE,
+                              "https://movie/x", 0.75, runtime=7200),
+            ]
+
+    class ExplodingProvider(MediaProvider):
+        name = "mock.boom"
+        media: Set[MVMediaType] = {MVMediaType.MUSIC}
+
+        def is_available(self) -> bool:
+            return True
+
+        def search(self, signals: Signals, lang: str = "en-us") -> List[Release]:
+            raise RuntimeError("boom")
+
+
+@unittest.skipUnless(HAS_MP, "ovos-plugin-manager MediaProvider type unavailable")
+class TestBridge(unittest.TestCase):
+    def test_release_to_ocp_result_fields(self):
+        rel = _make_release("Black Album", MVMediaType.MUSIC,
+                            "https://music/black", 0.85, artist="Metallica",
+                            runtime=3600)
+        d = release_to_ocp_result(rel, "mock.music")
+        self.assertEqual(d["uri"], "https://music/black")
+        self.assertEqual(d["title"], "Black Album")
+        self.assertEqual(d["image"], "Black Album.png")
+        self.assertEqual(d["artist"], "Metallica")
+        self.assertEqual(d["length"], 3600)
+        self.assertEqual(d["media_type"], OCPMediaType.MUSIC)
+        self.assertEqual(d["playback"], OCPPlaybackType.AUDIO)
+        # 0.85 float -> 85 int
+        self.assertEqual(d["match_confidence"], 85)
+        self.assertEqual(d["skill_id"], "mock.music")
+
+    def test_confidence_clamped_and_scaled(self):
+        rel = _make_release("x", MVMediaType.MUSIC, "u", 1.0)
+        self.assertEqual(release_to_ocp_result(rel, "p")["match_confidence"], 100)
+        rel0 = _make_release("x", MVMediaType.MUSIC, "u", 0.0)
+        self.assertEqual(release_to_ocp_result(rel0, "p")["match_confidence"], 0)
+
+    def test_no_credit_artist_empty(self):
+        rel = _make_release("x", MVMediaType.MOVIE, "u", 0.5)
+        self.assertEqual(release_to_ocp_result(rel, "p")["artist"], "")
+
+    def test_playback_type_mapping(self):
+        self.assertEqual(mediavocab_playback_to_ocp(MVPlaybackType.AUDIO),
+                         OCPPlaybackType.AUDIO)
+        self.assertEqual(mediavocab_playback_to_ocp(MVPlaybackType.VIDEO),
+                         OCPPlaybackType.VIDEO)
+        self.assertEqual(mediavocab_playback_to_ocp(MVPlaybackType.INTERACTIVE),
+                         OCPPlaybackType.SKILL)
+        self.assertEqual(mediavocab_playback_to_ocp(MVPlaybackType.PAGED),
+                         OCPPlaybackType.WEBVIEW)
+
+    def test_interactive_release_maps_to_skill(self):
+        rel = _make_release("A Game", MVMediaType.GAME, "u", 0.5)
+        d = release_to_ocp_result(rel, "p")
+        self.assertEqual(d["playback"], OCPPlaybackType.SKILL)
+        self.assertEqual(d["media_type"], OCPMediaType.GAME)
+
+    def test_paged_release_maps_to_webview(self):
+        rel = _make_release("A Comic", MVMediaType.COMIC, "u", 0.5)
+        d = release_to_ocp_result(rel, "p")
+        self.assertEqual(d["playback"], OCPPlaybackType.WEBVIEW)
+
+    def test_media_type_to_signals(self):
+        sig = media_type_to_signals(OCPMediaType.MUSIC, "metallica")
+        self.assertEqual(sig.medium, MVMediaType.MUSIC)
+        self.assertEqual(sig.title, "metallica")
+        self.assertEqual(sig.playback_type, MVPlaybackType.AUDIO)
+
+    def test_generic_signals_typeless(self):
+        sig = media_type_to_signals(OCPMediaType.GENERIC, "anything")
+        self.assertIsNone(sig.medium)
+        self.assertIsNone(ocp_media_type_to_mediavocab(OCPMediaType.GENERIC))
+
+    def test_reverse_media_mapping(self):
+        self.assertEqual(mediavocab_media_type_to_ocp(MVMediaType.MUSIC),
+                         OCPMediaType.MUSIC)
+        self.assertEqual(mediavocab_media_type_to_ocp(MVMediaType.MOVIE),
+                         OCPMediaType.MOVIE)
+
+
+@unittest.skipUnless(HAS_MP, "ovos-plugin-manager MediaProvider type unavailable")
+class TestProviderDispatch(unittest.TestCase):
+    def setUp(self):
+        self.ocp = OCPPipelineMatcher(config={})
+
+    def _install(self, *providers):
+        self.ocp.media_providers = {p.name: p for p in providers}
+
+    def test_routing_gate_skips_non_matching(self):
+        # only MovieProvider installed; a MUSIC query must not reach it
+        self._install(MovieProvider())
+        results = self.ocp._search_providers("metallica", OCPMediaType.MUSIC,
+                                             "en-us")
+        self.assertEqual(results, [])
+
+    def test_routing_gate_matches(self):
+        self._install(MovieProvider())
+        results = self.ocp._search_providers("some movie", OCPMediaType.MOVIE,
+                                             "en-us")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["title"], "Some Movie")
+
+    def test_dispatch_returns_bridged_results(self):
+        self._install(MusicProvider())
+        results = self.ocp._search_providers("metallica", OCPMediaType.MUSIC,
+                                             "en-us")
+        self.assertEqual(len(results), 2)
+        titles = {r["title"] for r in results}
+        self.assertEqual(titles, {"Black Album", "Ride the Lightning"})
+        for r in results:
+            self.assertEqual(r["skill_id"], "mock.music")
+            self.assertEqual(r["media_type"], OCPMediaType.MUSIC)
+
+    def test_multiple_providers_concurrent(self):
+        # both gate on different media; a generic query (no medium) reaches both
+        self._install(MusicProvider(), MovieProvider())
+        results = self.ocp._search_providers("anything", OCPMediaType.GENERIC,
+                                             "en-us")
+        uris = {r["uri"] for r in results}
+        self.assertIn("https://music/black", uris)
+        self.assertIn("https://movie/x", uris)
+
+    def test_exploding_provider_is_isolated(self):
+        # search_safe swallows the error; other providers still return
+        self._install(MusicProvider(), ExplodingProvider())
+        results = self.ocp._search_providers("metallica", OCPMediaType.MUSIC,
+                                             "en-us")
+        # only the 2 music results, boom contributed nothing and didn't abort
+        self.assertEqual(len(results), 2)
+
+    def test_no_providers_returns_empty(self):
+        self.ocp.media_providers = {}
+        self.assertEqual(
+            self.ocp._search_providers("x", OCPMediaType.MUSIC, "en-us"), [])
+
+    def test_dispatch_results_rank_via_select_best(self):
+        self._install(MusicProvider())
+        results = self.ocp._search_providers("metallica", OCPMediaType.MUSIC,
+                                             "en-us")
+        normalized = self.ocp.normalize_results(results)
+        best = self.ocp.select_best(normalized, message=None)
+        # 0.9 (Black Album) outranks 0.6 (Ride the Lightning)
+        self.assertEqual(best.title, "Black Album")
+        self.assertEqual(best.match_confidence, 90)
+
+
+class TestProviderConfigGate(unittest.TestCase):
+    def test_no_providers_installed_behaves_as_today(self):
+        # default init with nothing installed/monkeypatched -> empty dict,
+        # dispatch is a no-op and the bus path is untouched.
+        ocp = OCPPipelineMatcher(config={})
+        if not HAS_MP:
+            self.assertEqual(ocp.media_providers, {})
+        # _search_providers must be safe to call regardless
+        self.assertEqual(
+            ocp._search_providers("x", OCPMediaType.MUSIC, "en-us"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_media_providers.py
+++ b/test/test_media_providers.py
@@ -1,28 +1,30 @@
-"""Unit tests for in-process MediaProvider dispatch and the Release->OCP bridge.
+"""Unit tests for in-process MediaProvider dispatch and the Release->OCP seam.
 
 These use mock ``MediaProvider`` subclasses returning synthetic
-``mediavocab.Release`` objects, registered via a monkeypatched
-``load_media_providers``. They cover:
+``mediavocab.Release`` objects. They cover:
 
 * the three-axis routing gate (a provider that can't serve a query is skipped),
 * concurrent dispatch returning ranked results,
-* the ``Release`` -> OCP result bridge field mapping,
+* the ``Release`` -> OCP result field mapping (mediavocab-native ``media_type``,
+  ``PlaybackType`` backend selector derived from mediavocab routing),
 * that bus-path behaviour is unchanged when no providers are installed.
+
+The pipeline is mediavocab-native: routing and result ``media_type`` use
+``mediavocab.MediaType`` directly. The only translation left is the playback
+*backend selector* (``ovos_utils.ocp.PlaybackType``), which is ``MediaEntry``
+structure, not a media-type taxonomy.
 """
 import unittest
 from typing import List, Set
 
-from mediavocab import MediaType as MVMediaType
+from mediavocab import MediaType
 from mediavocab import EntityKind, Release, Signals, Work
 from mediavocab.models.entity import Credit, EntityRef
 from mediavocab.taxonomy import PlaybackType as MVPlaybackType
 
-from ovos_utils.ocp import MediaType as OCPMediaType
 from ovos_utils.ocp import PlaybackType as OCPPlaybackType
 
 from ocp_pipeline.bridge import (release_to_ocp_result, media_type_to_signals,
-                                 ocp_media_type_to_mediavocab,
-                                 mediavocab_media_type_to_ocp,
                                  mediavocab_playback_to_ocp)
 from ocp_pipeline.opm import OCPPipelineMatcher
 
@@ -34,7 +36,7 @@ except ImportError:
     HAS_MP = False
 
 
-def _make_release(title: str, media_type: MVMediaType, uri: str,
+def _make_release(title: str, media_type: MediaType, uri: str,
                   conf: float, artist: str = "", runtime: float = 0) -> Release:
     credits = []
     if artist:
@@ -49,36 +51,36 @@ def _make_release(title: str, media_type: MVMediaType, uri: str,
 if HAS_MP:
     class MusicProvider(MediaProvider):
         name = "mock.music"
-        media: Set[MVMediaType] = {MVMediaType.MUSIC}
+        media: Set[MediaType] = {MediaType.MUSIC}
 
         def is_available(self) -> bool:
             return True
 
         def search(self, signals: Signals, lang: str = "en-us") -> List[Release]:
             return [
-                _make_release("Black Album", MVMediaType.MUSIC,
+                _make_release("Black Album", MediaType.MUSIC,
                               "https://music/black", 0.9, artist="Metallica",
                               runtime=3600),
-                _make_release("Ride the Lightning", MVMediaType.MUSIC,
+                _make_release("Ride the Lightning", MediaType.MUSIC,
                               "https://music/ride", 0.6, artist="Metallica"),
             ]
 
     class MovieProvider(MediaProvider):
         name = "mock.movie"
-        media: Set[MVMediaType] = {MVMediaType.MOVIE}
+        media: Set[MediaType] = {MediaType.MOVIE}
 
         def is_available(self) -> bool:
             return True
 
         def search(self, signals: Signals, lang: str = "en-us") -> List[Release]:
             return [
-                _make_release("Some Movie", MVMediaType.MOVIE,
+                _make_release("Some Movie", MediaType.MOVIE,
                               "https://movie/x", 0.75, runtime=7200),
             ]
 
     class ExplodingProvider(MediaProvider):
         name = "mock.boom"
-        media: Set[MVMediaType] = {MVMediaType.MUSIC}
+        media: Set[MediaType] = {MediaType.MUSIC}
 
         def is_available(self) -> bool:
             return True
@@ -90,7 +92,7 @@ if HAS_MP:
 @unittest.skipUnless(HAS_MP, "ovos-plugin-manager MediaProvider type unavailable")
 class TestBridge(unittest.TestCase):
     def test_release_to_ocp_result_fields(self):
-        rel = _make_release("Black Album", MVMediaType.MUSIC,
+        rel = _make_release("Black Album", MediaType.MUSIC,
                             "https://music/black", 0.85, artist="Metallica",
                             runtime=3600)
         d = release_to_ocp_result(rel, "mock.music")
@@ -99,20 +101,21 @@ class TestBridge(unittest.TestCase):
         self.assertEqual(d["image"], "Black Album.png")
         self.assertEqual(d["artist"], "Metallica")
         self.assertEqual(d["length"], 3600)
-        self.assertEqual(d["media_type"], OCPMediaType.MUSIC)
+        # media_type is the mediavocab value directly
+        self.assertEqual(d["media_type"], MediaType.MUSIC)
         self.assertEqual(d["playback"], OCPPlaybackType.AUDIO)
         # 0.85 float -> 85 int
         self.assertEqual(d["match_confidence"], 85)
         self.assertEqual(d["skill_id"], "mock.music")
 
     def test_confidence_clamped_and_scaled(self):
-        rel = _make_release("x", MVMediaType.MUSIC, "u", 1.0)
+        rel = _make_release("x", MediaType.MUSIC, "u", 1.0)
         self.assertEqual(release_to_ocp_result(rel, "p")["match_confidence"], 100)
-        rel0 = _make_release("x", MVMediaType.MUSIC, "u", 0.0)
+        rel0 = _make_release("x", MediaType.MUSIC, "u", 0.0)
         self.assertEqual(release_to_ocp_result(rel0, "p")["match_confidence"], 0)
 
     def test_no_credit_artist_empty(self):
-        rel = _make_release("x", MVMediaType.MOVIE, "u", 0.5)
+        rel = _make_release("x", MediaType.MOVIE, "u", 0.5)
         self.assertEqual(release_to_ocp_result(rel, "p")["artist"], "")
 
     def test_playback_type_mapping(self):
@@ -126,32 +129,25 @@ class TestBridge(unittest.TestCase):
                          OCPPlaybackType.WEBVIEW)
 
     def test_interactive_release_maps_to_skill(self):
-        rel = _make_release("A Game", MVMediaType.GAME, "u", 0.5)
+        rel = _make_release("A Game", MediaType.GAME, "u", 0.5)
         d = release_to_ocp_result(rel, "p")
         self.assertEqual(d["playback"], OCPPlaybackType.SKILL)
-        self.assertEqual(d["media_type"], OCPMediaType.GAME)
+        self.assertEqual(d["media_type"], MediaType.GAME)
 
     def test_paged_release_maps_to_webview(self):
-        rel = _make_release("A Comic", MVMediaType.COMIC, "u", 0.5)
+        rel = _make_release("A Comic", MediaType.COMIC, "u", 0.5)
         d = release_to_ocp_result(rel, "p")
         self.assertEqual(d["playback"], OCPPlaybackType.WEBVIEW)
 
     def test_media_type_to_signals(self):
-        sig = media_type_to_signals(OCPMediaType.MUSIC, "metallica")
-        self.assertEqual(sig.medium, MVMediaType.MUSIC)
+        sig = media_type_to_signals(MediaType.MUSIC, "metallica")
+        self.assertEqual(sig.medium, MediaType.MUSIC)
         self.assertEqual(sig.title, "metallica")
         self.assertEqual(sig.playback_type, MVPlaybackType.AUDIO)
 
     def test_generic_signals_typeless(self):
-        sig = media_type_to_signals(OCPMediaType.GENERIC, "anything")
+        sig = media_type_to_signals(MediaType.GENERIC, "anything")
         self.assertIsNone(sig.medium)
-        self.assertIsNone(ocp_media_type_to_mediavocab(OCPMediaType.GENERIC))
-
-    def test_reverse_media_mapping(self):
-        self.assertEqual(mediavocab_media_type_to_ocp(MVMediaType.MUSIC),
-                         OCPMediaType.MUSIC)
-        self.assertEqual(mediavocab_media_type_to_ocp(MVMediaType.MOVIE),
-                         OCPMediaType.MOVIE)
 
 
 @unittest.skipUnless(HAS_MP, "ovos-plugin-manager MediaProvider type unavailable")
@@ -165,32 +161,32 @@ class TestProviderDispatch(unittest.TestCase):
     def test_routing_gate_skips_non_matching(self):
         # only MovieProvider installed; a MUSIC query must not reach it
         self._install(MovieProvider())
-        results = self.ocp._search_providers("metallica", OCPMediaType.MUSIC,
+        results = self.ocp._search_providers("metallica", MediaType.MUSIC,
                                              "en-us")
         self.assertEqual(results, [])
 
     def test_routing_gate_matches(self):
         self._install(MovieProvider())
-        results = self.ocp._search_providers("some movie", OCPMediaType.MOVIE,
+        results = self.ocp._search_providers("some movie", MediaType.MOVIE,
                                              "en-us")
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["title"], "Some Movie")
 
     def test_dispatch_returns_bridged_results(self):
         self._install(MusicProvider())
-        results = self.ocp._search_providers("metallica", OCPMediaType.MUSIC,
+        results = self.ocp._search_providers("metallica", MediaType.MUSIC,
                                              "en-us")
         self.assertEqual(len(results), 2)
         titles = {r["title"] for r in results}
         self.assertEqual(titles, {"Black Album", "Ride the Lightning"})
         for r in results:
             self.assertEqual(r["skill_id"], "mock.music")
-            self.assertEqual(r["media_type"], OCPMediaType.MUSIC)
+            self.assertEqual(r["media_type"], MediaType.MUSIC)
 
     def test_multiple_providers_concurrent(self):
         # both gate on different media; a generic query (no medium) reaches both
         self._install(MusicProvider(), MovieProvider())
-        results = self.ocp._search_providers("anything", OCPMediaType.GENERIC,
+        results = self.ocp._search_providers("anything", MediaType.GENERIC,
                                              "en-us")
         uris = {r["uri"] for r in results}
         self.assertIn("https://music/black", uris)
@@ -199,7 +195,7 @@ class TestProviderDispatch(unittest.TestCase):
     def test_exploding_provider_is_isolated(self):
         # search_safe swallows the error; other providers still return
         self._install(MusicProvider(), ExplodingProvider())
-        results = self.ocp._search_providers("metallica", OCPMediaType.MUSIC,
+        results = self.ocp._search_providers("metallica", MediaType.MUSIC,
                                              "en-us")
         # only the 2 music results, boom contributed nothing and didn't abort
         self.assertEqual(len(results), 2)
@@ -207,11 +203,11 @@ class TestProviderDispatch(unittest.TestCase):
     def test_no_providers_returns_empty(self):
         self.ocp.media_providers = {}
         self.assertEqual(
-            self.ocp._search_providers("x", OCPMediaType.MUSIC, "en-us"), [])
+            self.ocp._search_providers("x", MediaType.MUSIC, "en-us"), [])
 
     def test_dispatch_results_rank_via_select_best(self):
         self._install(MusicProvider())
-        results = self.ocp._search_providers("metallica", OCPMediaType.MUSIC,
+        results = self.ocp._search_providers("metallica", MediaType.MUSIC,
                                              "en-us")
         normalized = self.ocp.normalize_results(results)
         best = self.ocp.select_best(normalized, message=None)
@@ -229,7 +225,7 @@ class TestProviderConfigGate(unittest.TestCase):
             self.assertEqual(ocp.media_providers, {})
         # _search_providers must be safe to call regardless
         self.assertEqual(
-            ocp._search_providers("x", OCPMediaType.MUSIC, "en-us"), [])
+            ocp._search_providers("x", MediaType.MUSIC, "en-us"), [])
 
 
 if __name__ == "__main__":

--- a/test/test_mediavocab_native_e2e.py
+++ b/test/test_mediavocab_native_e2e.py
@@ -1,0 +1,101 @@
+"""End-to-end proof that the OCP pipeline is fully mediavocab-native.
+
+Two things are asserted here:
+
+1. **Behaviour** -- the *real* ``ovos-media-classifier`` (not mocked) classifies
+   real utterances and ``classify_media`` / ``is_ocp_query`` return the correct
+   ``mediavocab.MediaType`` / bool, with no ``ovos_utils.ocp`` taxonomy in the
+   loop.
+2. **Source hygiene** -- the legacy ``ovos_utils.ocp.MediaType`` taxonomy import
+   is gone from ``opm.py``/``legacy.py``, and the old ocp<->mediavocab media-type
+   bridge functions/maps no longer exist in ``ocp_pipeline.bridge``.
+"""
+import inspect
+import unittest
+
+from mediavocab import MediaType
+
+from ovos_utils.fakebus import FakeBus
+
+import ocp_pipeline.opm as opm_module
+import ocp_pipeline.legacy as legacy_module
+import ocp_pipeline.bridge as bridge_module
+from ocp_pipeline.opm import OCPPipelineMatcher
+
+
+class TestMediavocabNativeClassification(unittest.TestCase):
+    """Real classifier; assert mediavocab-native results."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ocp = OCPPipelineMatcher(bus=FakeBus())
+
+    def test_classify_media_returns_mediavocab_types(self):
+        cases = {
+            "play some music": MediaType.MUSIC,
+            "watch a movie": MediaType.MOVIE,
+            "play a podcast": MediaType.PODCAST,
+            # mediavocab has no ANIME label -> EPISODIC_SERIES
+            "i want to watch an anime": MediaType.EPISODIC_SERIES,
+            # mediavocab folds news into RADIO
+            "play the news": MediaType.RADIO,
+        }
+        for query, expected in cases.items():
+            media, conf = self.ocp.classify_media(query, "en-US")
+            self.assertIsInstance(media, MediaType)
+            self.assertEqual(media, expected,
+                             f"{query!r} -> {media} (expected {expected})")
+            self.assertIsInstance(conf, float)
+            self.assertGreater(conf, 0.0)
+
+    def test_non_media_is_generic_and_not_ocp(self):
+        media, conf = self.ocp.classify_media("what time is it", "en-US")
+        self.assertEqual(media, MediaType.GENERIC)
+        self.assertEqual(conf, 0.0)
+        is_ocp, _ = self.ocp.is_ocp_query("what time is it", "en-US")
+        self.assertFalse(is_ocp)
+
+    def test_is_ocp_query_true_for_media(self):
+        for query in ("play some music", "watch a movie", "play a podcast",
+                      "i want to watch an anime", "play the news"):
+            is_ocp, _ = self.ocp.is_ocp_query(query, "en-US")
+            self.assertTrue(is_ocp, f"{query!r} should be an OCP query")
+
+
+class TestNoOcpTaxonomyInSource(unittest.TestCase):
+    """The legacy ocp.MediaType taxonomy and its bridge must be gone."""
+
+    def test_opm_does_not_import_ocp_mediatype(self):
+        src = inspect.getsource(opm_module)
+        self.assertNotIn("from ovos_utils.ocp import MediaType", src)
+        # also guard against `ovos_utils.ocp ... MediaType` on one import line
+        for line in src.splitlines():
+            if "import" in line and "ovos_utils.ocp" in line:
+                self.assertNotIn("MediaType", line,
+                                 f"opm.py still imports ocp.MediaType: {line!r}")
+        # the module's MediaType symbol must be the mediavocab one
+        self.assertIs(opm_module.MediaType, MediaType)
+
+    def test_legacy_uses_mediavocab_mediatype(self):
+        self.assertIs(legacy_module.MediaType, MediaType)
+        src = inspect.getsource(legacy_module)
+        for line in src.splitlines():
+            if "import" in line and "ovos_utils.ocp" in line:
+                self.assertNotIn("MediaType", line)
+
+    def test_bridge_has_no_media_type_bridge(self):
+        for gone in ("ocp_media_type_to_mediavocab",
+                     "mediavocab_media_type_to_ocp",
+                     "_OCP_TO_MV_MEDIA", "_MV_TO_OCP_MEDIA"):
+            self.assertFalse(hasattr(bridge_module, gone),
+                             f"bridge.py still exposes {gone}")
+
+    def test_bridge_keeps_playback_selector_and_signals(self):
+        # the playback backend-selector map is MediaEntry structure, kept
+        self.assertTrue(hasattr(bridge_module, "mediavocab_playback_to_ocp"))
+        self.assertTrue(hasattr(bridge_module, "media_type_to_signals"))
+        self.assertTrue(hasattr(bridge_module, "release_to_ocp_result"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_ocp.py
+++ b/test/test_ocp.py
@@ -6,11 +6,15 @@ real (localized) .voc resource files. Media-type detection is delegated to
 files); the previous ovos-classifiers based predictor was removed (see #97),
 so detection only fires on explicit media keywords present in the .voc files,
 not on free-text artist/title guesses.
+
+The pipeline is mediavocab-native: classification returns
+``mediavocab.MediaType`` values, not the legacy ``ovos_utils.ocp.MediaType``
+taxonomy.
 """
 import os.path
 import unittest
 
-from ovos_utils.ocp import MediaType
+from mediavocab import MediaType
 
 import ocp_pipeline.opm
 from ocp_pipeline.opm import OCPPipelineMatcher
@@ -70,7 +74,7 @@ class TestOCPPipelineMatcher(unittest.TestCase):
             ocp_pipeline.opm.Message("", {
                 "skill_id": "fake",
                 "label": "music_streaming_service",
-                "media_type": int(MediaType.MUSIC),
+                "media_type": MediaType.MUSIC.value,
                 "samples": ["spotify"],
             })
         )

--- a/test/test_ocp.py
+++ b/test/test_ocp.py
@@ -1,10 +1,11 @@
 """Integration tests for OCPPipelineMatcher using the real __init__.
 
 These exercise the full match_high / match_medium / match_low flow against the
-real (localized) .voc resource files. Media-type detection is done by
-``voc_match_media`` (keyword matching); the previous ovos-classifiers based
-predictor was removed (see #97), so detection only fires on explicit media
-keywords present in the .voc files, not on free-text artist/title guesses.
+real (localized) .voc resource files. Media-type detection is delegated to
+``ovos-media-classifier`` (keyword matching over the pipeline's own .voc
+files); the previous ovos-classifiers based predictor was removed (see #97),
+so detection only fires on explicit media keywords present in the .voc files,
+not on free-text artist/title guesses.
 """
 import os.path
 import unittest
@@ -91,7 +92,7 @@ class TestOCPPipelineMatcher(unittest.TestCase):
         self.assertFalse(self.ocp.is_ocp_query("you suck", "en-US")[0])
 
     # ------------------------------------------------------------------ #
-    # classify_media (voc_match_media)
+    # classify_media (delegated to ovos-media-classifier)
     # ------------------------------------------------------------------ #
     def test_classify_media_by_keyword(self):
         self.assertEqual(

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -153,7 +153,7 @@ class TestNormalizeResults(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# classify_media / voc_match_media
+# classify_media (delegated to ovos-media-classifier + mediavocab<->ocp bridge)
 # ---------------------------------------------------------------------------
 
 class TestClassifyMedia(unittest.TestCase):
@@ -208,6 +208,32 @@ class TestClassifyMedia(unittest.TestCase):
         p.voc_match = _voc
         media, conf = p.classify_media("play radio", "en-us")
         self.assertEqual(media, MediaType.RADIO)
+
+    def test_anime_keyword_converges_to_video_episodes(self):
+        """Taxonomy convergence: an AnimeKeyword hit classifies through
+        mediavocab EPISODIC_SERIES and surfaces as ocp VIDEO_EPISODES (the
+        standalone classifier has no separate ANIME label)."""
+        p = _make_pipeline()
+        p.media2skill = {m: ["skill-x"] for m in MediaType}
+
+        def _voc(phrase, vocab, **kw):
+            return vocab == "AnimeKeyword"
+
+        p.voc_match = _voc
+        media, _ = p.classify_media("i want to watch an anime", "en-us")
+        self.assertEqual(media, MediaType.VIDEO_EPISODES)
+
+    def test_documentary_keyword_converges_to_movie(self):
+        """DocumentaryKeyword -> mediavocab MOVIE -> ocp MOVIE."""
+        p = _make_pipeline()
+        p.media2skill = {m: ["skill-x"] for m in MediaType}
+
+        def _voc(phrase, vocab, **kw):
+            return vocab == "DocumentaryKeyword"
+
+        p.voc_match = _voc
+        media, _ = p.classify_media("show me a documentary", "en-us")
+        self.assertEqual(media, MediaType.MOVIE)
 
     def test_valid_labels_filter_limits_candidates(self):
         """If valid_labels excludes a type, that type must not be returned."""

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -8,7 +8,8 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from ovos_utils.fakebus import FakeBus
-from ovos_utils.ocp import MediaType, PlayerState, MediaState, TrackState, MediaEntry
+from ovos_utils.ocp import PlayerState, MediaState, TrackState, MediaEntry
+from mediavocab import MediaType
 
 
 # ---------------------------------------------------------------------------
@@ -98,12 +99,18 @@ class TestNormalizeMediaEnum(unittest.TestCase):
         result = OCPPipelineMatcher._normalize_media_enum(MediaType.MUSIC)
         self.assertEqual(result, MediaType.MUSIC)
 
-    def test_int_converted_to_enum(self):
+    def test_value_converted_to_enum(self):
+        """mediavocab is a str-enum: its value (e.g. 'music') round-trips."""
         from ocp_pipeline.opm import OCPPipelineMatcher
-        result = OCPPipelineMatcher._normalize_media_enum(int(MediaType.MUSIC))
+        result = OCPPipelineMatcher._normalize_media_enum(MediaType.MUSIC.value)
         self.assertEqual(result, MediaType.MUSIC)
 
-    def test_invalid_int_raises(self):
+    def test_name_converted_to_enum(self):
+        from ocp_pipeline.opm import OCPPipelineMatcher
+        result = OCPPipelineMatcher._normalize_media_enum("MUSIC")
+        self.assertEqual(result, MediaType.MUSIC)
+
+    def test_invalid_token_raises(self):
         from ocp_pipeline.opm import OCPPipelineMatcher
         with self.assertRaises((ValueError, Exception)):
             OCPPipelineMatcher._normalize_media_enum(99999)
@@ -126,7 +133,7 @@ class TestNormalizeResults(unittest.TestCase):
     def test_valid_dict_converted_to_entry(self):
         from ocp_pipeline.opm import OCPPipelineMatcher
         d = {"uri": "http://example.com/t.mp3", "title": "Track",
-             "media_type": int(MediaType.MUSIC),
+             "media_type": MediaType.MUSIC.value,
              "playback": 2, "match_confidence": 75}
         out = OCPPipelineMatcher.normalize_results([d])
         self.assertEqual(len(out), 1)
@@ -146,14 +153,14 @@ class TestNormalizeResults(unittest.TestCase):
         from ocp_pipeline.opm import OCPPipelineMatcher
         entry = MediaEntry(uri="http://x.com/t.mp3", title="X")
         valid_dict = {"uri": "http://y.com/t.mp3", "title": "Y",
-                      "media_type": int(MediaType.MUSIC),
+                      "media_type": MediaType.MUSIC.value,
                       "playback": 2, "match_confidence": 60}
         out = OCPPipelineMatcher.normalize_results([entry, valid_dict, {"bad": True}])
         self.assertEqual(len(out), 2)
 
 
 # ---------------------------------------------------------------------------
-# classify_media (delegated to ovos-media-classifier + mediavocab<->ocp bridge)
+# classify_media (delegated to mediavocab-native ovos-media-classifier)
 # ---------------------------------------------------------------------------
 
 class TestClassifyMedia(unittest.TestCase):
@@ -209,10 +216,9 @@ class TestClassifyMedia(unittest.TestCase):
         media, conf = p.classify_media("play radio", "en-us")
         self.assertEqual(media, MediaType.RADIO)
 
-    def test_anime_keyword_converges_to_video_episodes(self):
-        """Taxonomy convergence: an AnimeKeyword hit classifies through
-        mediavocab EPISODIC_SERIES and surfaces as ocp VIDEO_EPISODES (the
-        standalone classifier has no separate ANIME label)."""
+    def test_anime_keyword_converges_to_episodic_series(self):
+        """Taxonomy convergence: an AnimeKeyword hit classifies to mediavocab
+        EPISODIC_SERIES (mediavocab has no separate ANIME label)."""
         p = _make_pipeline()
         p.media2skill = {m: ["skill-x"] for m in MediaType}
 
@@ -221,10 +227,10 @@ class TestClassifyMedia(unittest.TestCase):
 
         p.voc_match = _voc
         media, _ = p.classify_media("i want to watch an anime", "en-us")
-        self.assertEqual(media, MediaType.VIDEO_EPISODES)
+        self.assertEqual(media, MediaType.EPISODIC_SERIES)
 
     def test_documentary_keyword_converges_to_movie(self):
-        """DocumentaryKeyword -> mediavocab MOVIE -> ocp MOVIE."""
+        """DocumentaryKeyword -> mediavocab MOVIE (no DOCUMENTARY label)."""
         p = _make_pipeline()
         p.media2skill = {m: ["skill-x"] for m in MediaType}
 
@@ -284,7 +290,7 @@ class TestHandleSkillRegister(unittest.TestCase):
         msg = Message("ovos.common_play.announce", data={
             "skill_id": skill_id,
             "skill_name": "Test Skill",
-            "media_types": media_types or [int(MediaType.MUSIC)],
+            "media_types": media_types or [MediaType.MUSIC.value],
             "aliases": aliases or ["Test Skill"],
             "featured_tracks": False,
             "thumbnail": "",
@@ -294,7 +300,7 @@ class TestHandleSkillRegister(unittest.TestCase):
     def test_skill_added_to_media2skill(self):
         p = _make_pipeline()
         self._register_skill(p, skill_id="music.skill",
-                             media_types=[int(MediaType.MUSIC)])
+                             media_types=[MediaType.MUSIC.value])
         self.assertIn("music.skill", p.media2skill[MediaType.MUSIC])
 
     def test_skill_aliases_stored(self):
@@ -306,8 +312,8 @@ class TestHandleSkillRegister(unittest.TestCase):
     def test_multiple_media_types_registered(self):
         p = _make_pipeline()
         self._register_skill(p, skill_id="av.skill",
-                             media_types=[int(MediaType.MUSIC),
-                                          int(MediaType.PODCAST)])
+                             media_types=[MediaType.MUSIC.value,
+                                          MediaType.PODCAST.value])
         self.assertIn("av.skill", p.media2skill[MediaType.MUSIC])
         self.assertIn("av.skill", p.media2skill[MediaType.PODCAST])
 
@@ -315,7 +321,7 @@ class TestHandleSkillRegister(unittest.TestCase):
         p = _make_pipeline()
         # Confirm that an alias for a MUSIC skill is added to the NER
         self._register_skill(p, skill_id="spotify.skill",
-                             media_types=[int(MediaType.MUSIC)],
+                             media_types=[MediaType.MUSIC.value],
                              aliases=["Spotify"])
         # The NER should be able to tag "Spotify" as music_streaming_service
         tags = p.ner.tag("play Spotify")
@@ -349,7 +355,7 @@ class TestHandleSkillKeywordRegister(unittest.TestCase):
         msg = Message("ovos.common_play.register_keyword", data={
             "skill_id": "music.skill",
             "label": "music_streaming_service",
-            "media_type": int(MediaType.MUSIC),
+            "media_type": MediaType.MUSIC.value,
             "samples": ["BandCamp", "SoundCloud"],
         })
         p.handle_skill_keyword_register(msg)
@@ -363,7 +369,7 @@ class TestHandleSkillKeywordRegister(unittest.TestCase):
         msg = Message("ovos.common_play.register_keyword", data={
             "skill_id": "music.skill",
             "label": "music_streaming_service",
-            "media_type": int(MediaType.MUSIC),
+            "media_type": MediaType.MUSIC.value,
             "samples": [],
         })
         p.handle_skill_keyword_register(msg)  # must not raise


### PR DESCRIPTION
The OCP pipeline is now **mediavocab-native**: there is no `ovos_utils.ocp.MediaType` taxonomy and no ocp<->mediavocab media-type bridge.

- Classification is delegated to **ovos-media-classifier** (mediavocab-native); `classify_media`/`is_ocp_query` return `mediavocab.MediaType` / bool directly, with no taxonomy translation.
- `bridge.py` drops the `_OCP_TO_MV_MEDIA`/`_MV_TO_OCP_MEDIA` maps and the `ocp_media_type_to_mediavocab`/`mediavocab_media_type_to_ocp` functions. `media_type_to_signals`/`release_to_ocp_result` consume and emit `mediavocab.MediaType`. Only the `PlaybackType` backend selector (AUDIO/VIDEO/SKILL/WEBVIEW) is kept — that is `MediaEntry` structure, not the media-type taxonomy.
- The **`MediaEntry` container** (and `PlaybackType`/`Playlist`) is kept from `ovos_utils.ocp`; its `media_type` field now carries a `mediavocab.MediaType`.
- Legacy keyword buckets converge onto mediavocab: anime/cartoon -> `EPISODIC_SERIES`, news -> `RADIO`, documentary -> `MOVIE`.
- Tests assert `mediavocab.MediaType` values; new `test/test_mediavocab_native_e2e.py` runs the **real** classifier end-to-end and asserts no `ovos_utils.ocp.MediaType` import remains in `opm.py`/`legacy.py` and no ocp<->mv bridge remains in `bridge.py`.
- CI git-installs `ovos-media-classifier`.

**BREAKING CHANGE**: the pipeline's public media-type taxonomy is now `mediavocab.MediaType`; `question_type` emitted to OCP skills and skill `media_type` registrations are mediavocab values, not `ovos_utils.ocp` ints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)