### PR TITLE
fix: gate pause/resume matches to actionable player states (OCP-1 §4.3)

### DIFF
--- a/ocp_pipeline/opm.py
+++ b/ocp_pipeline/opm.py
@@ -384,11 +384,20 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             LOG.info(f'Ignoring OCP intent match {match["name"]}, OCP Virtual Player is not active')
             # next / previous / pause / resume not targeted
             # at OCP if playback is not happening / paused
-            if match["name"] == "resume":
-                # TODO - handle resume for last_played query, eg, previous day
-                return None
-            else:
-                return None
+            # TODO - handle resume for last_played query, eg, previous day
+            return None
+
+        # a control intent only matches when the player is in a state it can
+        # act on (OCP-1 §4.3): pausing requires advancing media, resuming
+        # requires held media. When the request could not change state, decline
+        # the match so the utterance falls through the pipeline instead of
+        # matching here and dead-ending in a no-op handler.
+        if match["name"] == "pause" and player.player_state != PlayerState.PLAYING:
+            LOG.info(f'Ignoring OCP pause match, nothing to pause (PlayerState: {player.player_state})')
+            return None
+        if match["name"] == "resume" and player.player_state != PlayerState.PAUSED:
+            LOG.info(f'Ignoring OCP resume match, nothing to resume (PlayerState: {player.player_state})')
+            return None
 
         return IntentHandlerMatch(match_type=f'ocp:{match["name"]}',
                                   match_data=match,

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -526,5 +526,78 @@ class TestUpdatePlayerSkillId(unittest.TestCase):
         self.assertEqual(result.skill_id, "original-skill")
 
 
+# ---------------------------------------------------------------------------
+# match_high control-intent gating — OCP-1 §4.3
+#
+# A control intent only matches when the player is in a state it can act on.
+# When it cannot act, the matcher must decline so the utterance falls through
+# the pipeline instead of matching here and dead-ending in a no-op handler.
+# ---------------------------------------------------------------------------
+
+class TestControlIntentGating(unittest.TestCase):
+
+    def _pipeline_with_player(self, intent_name, player_state):
+        from ocp_pipeline.opm import OCPPlayerProxy
+        p = _make_pipeline()
+        p.skill_aliases = {"ovos-skill-test": ["test"]}
+        # match_high routes on the intent name returned by the lang matcher;
+        # stub language resolution and the intent classifier so the state
+        # gate is what the test exercises.
+        p._get_closest_lang = MagicMock(return_value="en-US")
+        matcher = MagicMock()
+        matcher.calc_intent.return_value = {"name": intent_name, "conf": 1.0,
+                                            "entities": {}}
+        p.intent_matchers = {"en-US": matcher}
+        proxy = OCPPlayerProxy(session_id="default", available_extractors=[],
+                               ocp_available=True, player_state=player_state,
+                               media_type=MediaType.MUSIC)
+        p.ocp_sessions["default"] = proxy
+        return p
+
+    def _match(self, intent_name, player_state):
+        p = self._pipeline_with_player(intent_name, player_state)
+        msg = _make_message(session_id="default")
+        return p.match_high([intent_name], "en-US", msg)
+
+    def test_pause_declined_when_stopped(self):
+        """Nothing to pause: matcher declines, utterance falls through."""
+        self.assertIsNone(self._match("pause", PlayerState.STOPPED))
+
+    def test_pause_declined_when_already_paused(self):
+        """Pausing held media is a no-op, so the matcher declines."""
+        self.assertIsNone(self._match("pause", PlayerState.PAUSED))
+
+    def test_pause_matches_when_playing(self):
+        """Pause is actionable only while advancing: match ocp:pause."""
+        result = self._match("pause", PlayerState.PLAYING)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_type, "ocp:pause")
+
+    def test_resume_declined_when_stopped(self):
+        self.assertIsNone(self._match("resume", PlayerState.STOPPED))
+
+    def test_resume_declined_when_playing(self):
+        """Resuming advancing media is a no-op, so the matcher declines."""
+        self.assertIsNone(self._match("resume", PlayerState.PLAYING))
+
+    def test_resume_matches_when_paused(self):
+        result = self._match("resume", PlayerState.PAUSED)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_type, "ocp:resume")
+
+    def test_next_declined_when_stopped(self):
+        self.assertIsNone(self._match("next", PlayerState.STOPPED))
+
+    def test_next_matches_when_playing(self):
+        result = self._match("next", PlayerState.PLAYING)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_type, "ocp:next")
+
+    def test_next_matches_when_paused(self):
+        result = self._match("next", PlayerState.PAUSED)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_type, "ocp:next")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

The OCP pipeline matched transport-control utterances that could not act on the player, then dead-ended in a handler that changed nothing. Concretely, `match_high` only declined control intents when the player was `STOPPED`; so:

- "pause" while already `PAUSED` matched `ocp:pause` and reached `handle_pause_intent`, which re-set `PAUSED` and re-emitted a pause command — a no-op the user got no feedback from.
- "resume" while `PLAYING` matched `ocp:resume` for the same dead-end.

A matcher that consumes the utterance and then does nothing is the wrong layer: the utterance never falls through to another pipeline stage or fallback.

## Spec

OVOS-OCP-1 §4.3 — control requests are idempotent with respect to absent media (issuing `pause` with nothing playing is a no-op, not an error). §8 requires the Virtual Media Player to treat such control requests as no-ops.

That no-op robustness rule governs the **player** when a command still arrives (an MPRIS button, a direct bus emit, a race). It is *not* satisfied by matching a voice utterance and dead-ending it. Per OVOS-PIPELINE-1, the pipeline should not match a control intent it cannot act on in the first place — it should let the utterance fall through.

## Change

Gate the match in `match_high`: a control intent only matches when the player is in a state it can act on.

- `pause` matches only when `PLAYING`.
- `resume` matches only when `PAUSED`.
- `next` / `prev` / `media_stop` were already correctly gated (declined only when `STOPPED`, i.e. actionable while `PLAYING` or `PAUSED`) — unchanged.

When a control request cannot change state, the matcher returns `None` and the utterance falls through the pipeline instead of being absorbed.

The handler-level no-op guard from the earlier revision is removed. `handle_pause_intent` is reachable only via the `ocp:pause` intent match — this plugin is the OVOS-PIPELINE-1 matcher/dispatcher, not the Virtual Media Player — so once the match is gated that guard is dead code. The §4.3 player-level no-op belongs to the actual media player (ovos-media / legacy AudioService) that receives `ovos.common_play.pause`, which is out of scope for this repo. The existing `_handle_legacy_audio_pause` state-mirror keeps its `== PLAYING` guard because it mirrors the legacy backend's own reported state, which is a separate concern from §4.3.

## Tests

`TestControlIntentGating` in `test/test_pipeline.py` asserts at the matcher layer:

- `pause`: declined when `STOPPED`, declined when `PAUSED`, matches `ocp:pause` when `PLAYING`.
- `resume`: declined when `STOPPED`, declined when `PLAYING`, matches `ocp:resume` when `PAUSED`.
- `next`: declined when `STOPPED`, matches `ocp:next` when `PLAYING` and when `PAUSED`.

The two tests targeting the closed gap (pause-while-paused, resume-while-playing) fail against the pre-change matcher and pass after. Full suite green (`uv run pytest test/`).