### PR TITLE
fix: restore {media} slot name in de-DE featured.intent

### DIFF
--- a/ocp_pipeline/locale/de-DE/featured.intent
+++ b/ocp_pipeline/locale/de-DE/featured.intent
@@ -1,21 +1,21 @@
-anzeigen vorgestellte {Medien}
-zeige  {Medien} Katalog
-zeige  {Medien} Sammlung
-zeige  {Medien} Wiedergabeliste
-zeige an  {Medien} Katalog
-zeige an  {Medien} Sammlung
-zeige an  {Medien} Wiedergabeliste
-zeige an vorgestellte {Medien} Katalog
-zeige an vorgestellte {Medien} Sammlung
-zeige an vorgestellte {Medien} Wiedergabeliste
-zeige vorgestellte {Medien} Katalog
-zeige vorgestellte {Medien} Sammlung
-zeige vorgestellte {Medien} Wiedergabeliste
-zeigen  vorgestellte {Medien}
-öffne  {Medien} Katalog
-öffne  {Medien} Sammlung
-öffne  {Medien} Wiedergabeliste
-öffne vorgestellte {Medien} Katalog
-öffne vorgestellte {Medien} Sammlung
-öffne vorgestellte {Medien} Wiedergabeliste
-öffnen  vorgestellte {Medien}
+anzeigen vorgestellte {media}
+zeige  {media} Katalog
+zeige  {media} Sammlung
+zeige  {media} Wiedergabeliste
+zeige an  {media} Katalog
+zeige an  {media} Sammlung
+zeige an  {media} Wiedergabeliste
+zeige an vorgestellte {media} Katalog
+zeige an vorgestellte {media} Sammlung
+zeige an vorgestellte {media} Wiedergabeliste
+zeige vorgestellte {media} Katalog
+zeige vorgestellte {media} Sammlung
+zeige vorgestellte {media} Wiedergabeliste
+zeigen  vorgestellte {media}
+öffne  {media} Katalog
+öffne  {media} Sammlung
+öffne  {media} Wiedergabeliste
+öffne vorgestellte {media} Katalog
+öffne vorgestellte {media} Sammlung
+öffne vorgestellte {media} Wiedergabeliste
+öffnen  vorgestellte {media}

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -3,3 +3,4 @@ flake8>=3.7.9
 pytest>=5.2.4
 pytest-cov>=2.8.1
 cov-core>=1.15.0
+ovos-spec-tools>=1.5.0a1

--- a/test/test_locale_templates.py
+++ b/test/test_locale_templates.py
@@ -1,0 +1,41 @@
+"""Validate that every locale resource file contains well-formed templates."""
+import os
+import unittest
+
+from ovos_spec_tools.expansion import expand
+
+PACKAGE_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                           "ocp_pipeline")
+LOCALE_EXTENSIONS = (".voc", ".intent", ".dialog", ".entity", ".rx")
+
+
+def iter_locale_files():
+    """Yield the path of every locale resource file in the package."""
+    for root, _dirs, files in os.walk(PACKAGE_DIR):
+        if os.sep + "locale" + os.sep not in root + os.sep:
+            continue
+        for fname in sorted(files):
+            if fname.endswith(LOCALE_EXTENSIONS):
+                yield os.path.join(root, fname)
+
+
+class TestLocaleTemplates(unittest.TestCase):
+    def test_all_locale_templates_expand(self):
+        failures = []
+        for path in iter_locale_files():
+            with open(path, encoding="utf-8") as f:
+                for lineno, line in enumerate(f, start=1):
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    try:
+                        expand(line)
+                    except Exception as e:
+                        rel = os.path.relpath(path, PACKAGE_DIR)
+                        failures.append(f"{rel}:{lineno}: {line!r} -> {e}")
+        self.assertEqual(failures, [],
+                         "Malformed locale templates found:\n" + "\n".join(failures))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The de-DE translation used a translated slot name `{Medien}`, which does not match the `{media}` slot consumed by the intent handler, leaving all 21 templates in the file unexpandable. Restores `{media}` while keeping the translated text, and adds a regression test that expands every locale template line (ovos-spec-tools added to test requirements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)