### PR TITLE
fix: resolve locale directories via closest_lang

### DIFF
--- a/ocp_pipeline/opm.py
+++ b/ocp_pipeline/opm.py
@@ -2,7 +2,7 @@ import os
 import random
 import threading
 from dataclasses import dataclass
-from os.path import join, dirname
+from os.path import join, dirname, isdir
 from threading import RLock
 from typing import Tuple, Optional, Dict, List, Union, Any
 
@@ -14,7 +14,6 @@ from ovos_bus_client.session import SessionManager
 from ovos_config import Configuration
 from ovos_plugin_manager.ocp import available_extractors
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch, ConfidenceMatcherPipeline, PipelinePlugin
-from ovos_utils.lang import get_language_dir
 from ovos_spec_tools import standardize_lang, closest_lang, voc_match
 from ovos_utils.log import LOG, deprecated, log_deprecation
 from ovos_utils.fakebus import FakeBus
@@ -100,7 +99,10 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         for lang in langs:
             lang = standardize_lang(lang)
             intents[lang] = {}
-            locale_folder = get_language_dir(join(dirname(__file__), "locale"), lang)
+            locale_root = join(dirname(__file__), "locale")
+            match = closest_lang(lang, [d for d in os.listdir(locale_root)
+                                        if isdir(join(locale_root, d))])
+            locale_folder = join(locale_root, match) if match else None
             if locale_folder is not None:
                 for f in os.listdir(locale_folder):
                     path = join(locale_folder, f)

--- a/test/test_locale_resolution.py
+++ b/test/test_locale_resolution.py
@@ -1,0 +1,25 @@
+"""Locale directory resolution no longer relies on the deprecated
+``ovos_utils.lang.get_language_dir`` helper."""
+import unittest
+import warnings
+
+import ocp_pipeline.opm as opm
+from ocp_pipeline.opm import OCPPipelineMatcher
+
+
+class TestLocaleResolution(unittest.TestCase):
+    def test_deprecated_helper_not_imported(self):
+        self.assertFalse(hasattr(opm, "get_language_dir"))
+
+    def test_load_resource_files_resolves_locale_without_deprecation(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            intents = OCPPipelineMatcher.load_resource_files()
+        self.assertIn("en-US", intents)
+        self.assertTrue(any(intents["en-US"].values()))
+        self.assertEqual(
+            [w for w in caught if "get_language_dir" in str(w.message)], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`ocp_pipeline.opm` imported `get_language_dir` from `ovos_utils.lang`, which is deprecated in favour of `closest_lang` from `ovos_spec_tools` (already imported and used elsewhere in this module).

The locale subdirectory for a language is now resolved directly: `closest_lang` selects the nearest available `<lang>/` directory name and the path is joined onto it — exactly what the deprecated helper does internally. No dependency floor change is needed, `closest_lang` has been available across the whole pinned `ovos-spec-tools` range.

Adds a regression test asserting the deprecated symbol is gone and `load_resource_files` still resolves the `en-US` locale with no deprecation emitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale resource resolution to select the closest available language folder.
  * Removed reliance on a deprecated language-directory helper.
  * Prevented related deprecation warnings while loading intent resources.

* **Tests**
  * Added coverage verifying locale resolution continues to work correctly, including `en-US` resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->