### PR TITLE
feat: resurrect in-process MediaProvider dispatch with dual-window merge

### DIFF
--- a/ocp_pipeline/bridge.py
+++ b/ocp_pipeline/bridge.py
@@ -1,0 +1,235 @@
+"""Seam between in-process ``MediaProvider`` plugins and the legacy OCP pipeline.
+
+``MediaProvider`` plugins (``opm.media.provider``) are the in-process
+replacement for the old bus-broadcast OCP search skills. They speak
+*mediavocab*: a provider consumes a :class:`mediavocab.Signals` query and
+returns :class:`mediavocab.Release` candidates.
+
+The OCP pipeline itself is **not** mediavocab-native (that classification
+migration is tracked separately, see PRs #142/#143) — it still classifies and
+routes on the legacy :class:`ovos_utils.ocp.MediaType` taxonomy. This module is
+therefore a best-effort two-way bridge between the two taxonomies, used only by
+the in-process provider dispatch path (:mod:`ocp_pipeline.opm`'s
+``_search_providers``); it does not touch ``classify_media``/``voc_match_media``.
+
+``mediavocab`` and the ``MediaProvider`` plugin type are optional dependencies:
+when either is unavailable this module still imports cleanly, but its
+functions are unusable (callers check ``_HAS_MEDIAVOCAB`` / degrade via
+``opm.py``'s own ``_HAS_MEDIA_PROVIDERS`` guard).
+"""
+from typing import Optional
+
+from ovos_utils.ocp import MediaType as OCPMediaType
+from ovos_utils.ocp import PlaybackType as OCPPlaybackType
+from ovos_utils.parse import fuzzy_match
+
+try:
+    import mediavocab
+    from mediavocab import MediaType as MVMediaType
+    from mediavocab import Release, Signals
+    from mediavocab.taxonomy import PlaybackType as MVPlaybackType
+    _HAS_MEDIAVOCAB = True
+except ImportError:
+    _HAS_MEDIAVOCAB = False
+
+
+if _HAS_MEDIAVOCAB:
+    # ovos_utils.ocp.MediaType -> mediavocab.MediaType, best-effort. mediavocab
+    # is a coarser/cleaner taxonomy, so several legacy buckets fold onto a
+    # single mediavocab type. AUDIO/VIDEO (generic, untyped) have no good
+    # target and stay unmapped (None) -- the Signals stays typeless so
+    # providers self-select via their own routing.
+    _OCP_TO_MV = {
+        OCPMediaType.MUSIC: MVMediaType.MUSIC,
+        OCPMediaType.AUDIOBOOK: MVMediaType.AUDIOBOOK,
+        OCPMediaType.GAME: MVMediaType.GAME,
+        OCPMediaType.PODCAST: MVMediaType.PODCAST,
+        OCPMediaType.RADIO: MVMediaType.RADIO,
+        OCPMediaType.NEWS: MVMediaType.RADIO,
+        OCPMediaType.TV: MVMediaType.TV,
+        OCPMediaType.MOVIE: MVMediaType.MOVIE,
+        OCPMediaType.TRAILER: MVMediaType.MOVIE,
+        OCPMediaType.VISUAL_STORY: MVMediaType.COMIC,
+        OCPMediaType.DOCUMENTARY: MVMediaType.MOVIE,
+        OCPMediaType.RADIO_THEATRE: MVMediaType.AUDIO_DRAMA,
+        OCPMediaType.SHORT_FILM: MVMediaType.SHORT_FILM,
+        OCPMediaType.SILENT_MOVIE: MVMediaType.MOVIE,
+        OCPMediaType.VIDEO_EPISODES: MVMediaType.EPISODIC_SERIES,
+        OCPMediaType.BLACK_WHITE_MOVIE: MVMediaType.MOVIE,
+        OCPMediaType.CARTOON: MVMediaType.EPISODIC_SERIES,
+        OCPMediaType.ANIME: MVMediaType.EPISODIC_SERIES,
+        OCPMediaType.ASMR: MVMediaType.PROCEDURAL_AMBIENT,
+        OCPMediaType.ADULT: MVMediaType.MOVIE,
+        OCPMediaType.HENTAI: MVMediaType.EPISODIC_SERIES,
+        OCPMediaType.ADULT_AUDIO: MVMediaType.MUSIC,
+    }
+
+    # mediavocab.MediaType -> ovos_utils.ocp.MediaType, for folding a
+    # provider's Release.work.media_type back into the MediaEntry shape the
+    # rest of the pipeline (filter_results, select_best, ...) expects.
+    _MV_TO_OCP = {
+        MVMediaType.MOVIE: OCPMediaType.MOVIE,
+        MVMediaType.SHORT_FILM: OCPMediaType.SHORT_FILM,
+        MVMediaType.EPISODIC_SERIES: OCPMediaType.VIDEO_EPISODES,
+        MVMediaType.TV: OCPMediaType.TV,
+        MVMediaType.MUSIC: OCPMediaType.MUSIC,
+        MVMediaType.MUSIC_VIDEO: OCPMediaType.VIDEO,
+        MVMediaType.PODCAST: OCPMediaType.PODCAST,
+        MVMediaType.AUDIOBOOK: OCPMediaType.AUDIOBOOK,
+        MVMediaType.AUDIO_DRAMA: OCPMediaType.RADIO_THEATRE,
+        MVMediaType.RADIO: OCPMediaType.RADIO,
+        MVMediaType.BOOK: OCPMediaType.VISUAL_STORY,
+        MVMediaType.COMIC: OCPMediaType.VISUAL_STORY,
+        MVMediaType.GAME: OCPMediaType.GAME,
+        MVMediaType.INTERACTIVE_FICTION: OCPMediaType.GAME,
+        MVMediaType.SOUND_EFFECT: OCPMediaType.AUDIO,
+        MVMediaType.PROCEDURAL_AMBIENT: OCPMediaType.ASMR,
+        MVMediaType.PLAYLIST: OCPMediaType.GENERIC,
+        MVMediaType.GENERIC: OCPMediaType.GENERIC,
+        MVMediaType.NOT_MEDIA: OCPMediaType.GENERIC,
+        MVMediaType.CONTROL: OCPMediaType.GENERIC,
+    }
+
+    # mediavocab routing taxonomy -> ovos_utils.ocp backend selector. This is
+    # NOT a media-type bridge: it maps mediavocab's playback routing
+    # (audio/video/paged/interactive) onto the OCP MediaEntry backend selector
+    # (which player to hand the track to).
+    _MV_PLAYBACK_TO_OCP = {
+        MVPlaybackType.AUDIO: OCPPlaybackType.AUDIO,
+        MVPlaybackType.VIDEO: OCPPlaybackType.VIDEO,
+        MVPlaybackType.INTERACTIVE: OCPPlaybackType.SKILL,
+        MVPlaybackType.PAGED: OCPPlaybackType.WEBVIEW,
+        MVPlaybackType.UNKNOWN: OCPPlaybackType.UNDEFINED,
+    }
+
+    def ocp_media_type_to_mediavocab(media_type: OCPMediaType) -> Optional["MVMediaType"]:
+        """Best-effort map of a legacy ``ovos_utils.ocp.MediaType`` onto a
+        ``mediavocab.MediaType``, for building the provider query ``Signals``.
+
+        Returns ``None`` for ``GENERIC``/untyped/unmapped types -- the
+        ``Signals`` stays typeless so providers self-select via their own
+        routing, exactly like an unclassified bus query would.
+        """
+        return _OCP_TO_MV.get(media_type)
+
+    def mediavocab_media_type_to_ocp(media_type) -> OCPMediaType:
+        """Best-effort map of a ``mediavocab.MediaType`` (a Release's media
+        type) back onto the legacy ``ovos_utils.ocp.MediaType`` taxonomy, so a
+        provider result fits the ``MediaEntry`` shape the rest of the pipeline
+        expects."""
+        return _MV_TO_OCP.get(media_type, OCPMediaType.GENERIC)
+
+    def mediavocab_playback_to_ocp(pb: "MVPlaybackType") -> OCPPlaybackType:
+        """Map a ``mediavocab.taxonomy.PlaybackType`` (routing) to an
+        ``ovos_utils.ocp.PlaybackType`` (``MediaEntry`` backend selector)."""
+        return _MV_PLAYBACK_TO_OCP.get(pb, OCPPlaybackType.UNDEFINED)
+
+    def media_type_to_signals(media_type: OCPMediaType, query: str,
+                              artist: Optional[str] = None) -> "Signals":
+        """Build a query-role :class:`mediavocab.Signals` from the pipeline's
+        classified legacy :class:`ovos_utils.ocp.MediaType` and free-text
+        query.
+
+        ``GENERIC`` (and anything with no mediavocab equivalent) stays
+        typeless so providers self-select via their own routing.
+        """
+        kwargs = {"title": query or None}
+        if artist:
+            kwargs["artist"] = artist
+        mv_type = ocp_media_type_to_mediavocab(media_type)
+        if mv_type is not None:
+            kwargs["medium"] = mv_type
+            kwargs["playback_type"] = mediavocab.infer_playback_type(mv_type)
+        return Signals.as_query(**kwargs)
+
+    def _first_credit_name(release: "Release") -> str:
+        """Best-effort 'artist' string: name of the first work credit."""
+        try:
+            credits = release.work.credits or []
+            if credits:
+                entity = credits[0].entity
+                return getattr(entity, "name", "") or ""
+        except Exception:
+            pass
+        return ""
+
+    def fallback_confidence(release: "Release",
+                            signals: Optional["Signals"] = None) -> float:
+        """Score a ``Release`` that a provider did not score itself.
+
+        Providers **should** set ``Release.match_confidence`` themselves: only
+        the provider knows how well its catalog hit matches the request. When
+        it does not (unset or ``0.0``), forwarding ``0`` would be fatal --
+        :meth:`OCPPipelineMatcher.filter_results` drops everything below
+        ``min_score`` (50 by default), so an unscored provider result could
+        never be played. This computes a best-effort fuzzy score of the
+        release title against the query signals instead, using the same
+        ``ovos_utils.parse.fuzzy_match`` utility the OVOS ecosystem ranks
+        with. The artist is folded in only when the query asked for one.
+
+        @param release: the unscored candidate.
+        @param signals: the query ``Signals`` the candidate was fetched for.
+        @return: a 0.0..1.0 confidence.
+        """
+        if signals is None:
+            return 0.0
+        title = (getattr(release.work, "title", "") or "").strip()
+        q_title = (getattr(signals, "title", "") or "").strip()
+        if not title or not q_title:
+            return 0.0
+        score = fuzzy_match(title.lower(), q_title.lower())
+        q_artist = (getattr(signals, "artist", "") or "").strip()
+        if q_artist:
+            artist = (_first_credit_name(release) or "").strip()
+            a_score = fuzzy_match(artist.lower(), q_artist.lower()) if artist else 0.0
+            score = (score + a_score) / 2
+        return max(0.0, min(1.0, score))
+
+    def release_to_ocp_result(release: "Release", provider_id: str,
+                              media_type: Optional[OCPMediaType] = None,
+                              signals: Optional["Signals"] = None) -> dict:
+        """Map a :class:`mediavocab.Release` to the OCP playback result dict
+        the pipeline normalizes, ranks and plays.
+
+        ``media_type`` is folded back to the legacy
+        :class:`ovos_utils.ocp.MediaType` the rest of the pipeline (e.g.
+        :meth:`OCPPipelineMatcher.filter_results`) still expects. Only
+        ``playback`` is otherwise derived, mapping mediavocab's routing onto
+        the OCP ``MediaEntry`` backend selector.
+
+        @param release: the catalog candidate returned by a provider.
+        @param provider_id: registry name of the provider; becomes ``skill_id``.
+        @param media_type: legacy media type to stamp on the result. Callers
+            pass the media type of the QUERY, because the result was fetched
+            for that query: the mediavocab fold is not injective (legacy NEWS
+            and RADIO both map to mediavocab RADIO, which folds back to
+            RADIO), so folding the Release's own type back would make
+            ``filter_results`` drop the result for a NEWS query. When
+            ``None``, the Release's own type is folded back.
+        @param signals: the query signals, used only to score a Release the
+            provider left unscored (see :func:`fallback_confidence`).
+        @return: a dict in the ``ovos_utils.ocp`` ``MediaEntry`` shape.
+        """
+        work = release.work
+        mv_media_type = work.media_type
+        if media_type is None:
+            media_type = mediavocab_media_type_to_ocp(mv_media_type)
+        playback = mediavocab_playback_to_ocp(mediavocab.infer_playback_type(mv_media_type))
+
+        # match_confidence: mediavocab is 0.0..1.0 float, OCP MediaEntry is 0..100 int
+        conf = release.match_confidence or 0.0
+        if not conf:
+            conf = fallback_confidence(release, signals)
+        match_conf = int(round(max(0.0, min(1.0, conf)) * 100))
+
+        return {
+            "uri": release.uri,
+            "title": work.title,
+            "image": release.image,
+            "artist": _first_credit_name(release),
+            "length": work.runtime or 0,
+            "media_type": media_type,
+            "playback": playback,
+            "match_confidence": match_conf,
+            "skill_id": provider_id,
+        }

--- a/ocp_pipeline/opm.py
+++ b/ocp_pipeline/opm.py
@@ -1,6 +1,8 @@
 import os
 import random
 import threading
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError, as_completed
+from urllib.parse import urlsplit, urlunsplit
 from dataclasses import dataclass
 from os.path import join, dirname, isdir
 from threading import RLock
@@ -24,6 +26,20 @@ from ovos_utils.xdg_utils import xdg_data_home
 from ovos_config.meta import get_xdg_base
 from ahocorasick_ner import AhocorasickNER
 from ocp_pipeline.legacy import LegacyCommonPlay
+
+try:
+    from ovos_plugin_manager.media_provider import load_media_providers
+    from ovos_plugin_manager.templates.media_provider import MediaProvider
+    from ocp_pipeline.bridge import media_type_to_signals, release_to_ocp_result
+    _HAS_MEDIA_PROVIDERS = True
+except ImportError:
+    # ovos-plugin-manager without the MediaProvider plugin type, and/or
+    # mediavocab missing. In-process provider dispatch silently degrades to
+    # the legacy bus-only OCP-skill path -- this is the back-compat guarantee.
+    load_media_providers = None
+    MediaProvider = None
+    media_type_to_signals = release_to_ocp_result = None
+    _HAS_MEDIA_PROVIDERS = False
 
 # .voc resources shipped with this plugin (locale/<lang>/<name>.voc).
 # Matched via ovos-spec-tools voc_match (OVOS-INTENT-2 §4.3 whole-word semantics)
@@ -85,6 +101,15 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         }
         self.entity_csvs = self.config.get("entity_csvs", [])  # user defined keyword csv files
         self.ner = AhocorasickNER()
+
+        # in-process MediaProvider plugins (opm.media.provider). These run
+        # ALONGSIDE the legacy bus-broadcast @ocp_search skill flow (not
+        # instead of it) -- both windows execute and their results are merged
+        # in `_search` via `_merge_provider_results`. When no providers are
+        # installed/loaded this dict stays empty and the pipeline behaves
+        # exactly like the pre-existing bus-only path (see `_search_providers`).
+        self.media_providers: Dict[str, "MediaProvider"] = {}
+        self._load_media_providers()
 
         self.register_ocp_api_events()
         self.register_ocp_intents()
@@ -176,6 +201,44 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         self.add_event("ocp:like_song", self.handle_like_intent, is_intent=True)
         self.add_event("ocp:save_game", self.handle_save_intent, is_intent=True)
         self.add_event("ocp:load_game", self.handle_load_intent, is_intent=True)
+
+    def _load_media_providers(self):
+        """Discover and instantiate installed ``opm.media.provider`` plugins.
+
+        ``load_media_providers`` instantiates every installed provider that is
+        not disabled by the per-provider ``enabled: false`` config gate.
+        Runtime availability (missing API key, no network, ...) is the
+        provider's own concern -- it simply returns ``[]`` from
+        :meth:`MediaProvider.search`. When the MediaProvider plugin type
+        (ovos-plugin-manager) or mediavocab is unavailable, or no providers
+        are installed/enabled, ``self.media_providers`` stays empty and
+        ``_search_providers`` is a guaranteed no-op: the pipeline behaves
+        exactly as the pre-existing bus-only OCP-skill path.
+
+        The whole in-process window has an explicit off-switch: setting
+        ``media_providers.enabled`` to ``false`` in the OCP pipeline config
+        skips loading entirely (default: enabled).
+        """
+        if not _HAS_MEDIA_PROVIDERS:
+            LOG.debug("MediaProvider plugin type unavailable; "
+                      "using bus-only OCP search")
+            return
+        cfg = self.config.get("media_providers", None)
+        if isinstance(cfg, dict) and cfg.get("enabled") is False:
+            # documented off-switch: `media_providers.enabled: false` in the
+            # OCP pipeline config disables the in-process window entirely and
+            # restores the pure legacy bus-only search.
+            LOG.info("in-process MediaProvider dispatch disabled by config "
+                     "(media_providers.enabled = false)")
+            return
+        try:
+            self.media_providers = load_media_providers(cfg) or {}
+            if self.media_providers:
+                LOG.info(f"Loaded {len(self.media_providers)} MediaProvider "
+                         f"plugins: {list(self.media_providers)}")
+        except Exception:
+            LOG.exception("failed to load MediaProvider plugins")
+            self.media_providers = {}
 
     def update_player_proxy(self, player: OCPPlayerProxy):
         """remember OCP session state"""
@@ -972,20 +1035,293 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
 
         return results
 
+    def _build_query_context(self, lang: str,
+                             message: Optional[Message] = None) -> dict:
+        """Build the request-context kwargs for the MediaProvider ``search``
+        contract, from the session/config.
+
+        The MediaProvider contract is a single ``search(signals, lang="en-us",
+        *, supported_playback_types, blocked_genres, region, session_id)``
+        call: there is no routing/gating API. The pipeline passes what it
+        knows about the request as explicit kwargs; each provider reads the
+        keys it cares about and self-filters (returning ``[]`` when it cannot
+        serve the query/context).
+
+        Returns the four context kwargs (all permissive by default):
+          * ``supported_playback_types`` -- e.g. ``{"audio", "video"}``;
+            empty => no device gate. Read from
+            ``media.supported_playback_types``.
+          * ``blocked_genres`` -- genre tags the content policy blocks, from
+            ``media_content_filter.blocked_genres`` plus
+            ``media_content_filter.allow_adult_content`` (default ``false``
+            => ``adult`` blocked).
+          * ``region`` -- ISO 3166-1 alpha-2 from
+            ``location.city.region.country.code``.
+          * ``session_id`` -- originating session id (from ``message`` when
+            given).
+
+        All four are **device/user** settings, not OCP pipeline settings:
+        they are read from the global :class:`ovos_config.Configuration`, not
+        from ``self.config`` (which is only the ``ocp`` pipeline sub-config
+        and never carries these keys).
+        """
+        config = Configuration()
+
+        media_cfg = config.get("media", {}) or {}
+        supported = set(media_cfg.get("supported_playback_types", []) or [])
+
+        cf = config.get("media_content_filter", {}) or {}
+        blocked = set(cf.get("blocked_genres", ["adult"]))
+        if config.get("allow_adult_content", cf.get("allow_adult_content", False)):
+            blocked.discard("adult")
+
+        region = None
+        loc = config.get("location", {}) or {}
+        code = (((loc.get("city") or {}).get("region") or {}).get("country") or {}).get("code")
+        if code:
+            region = str(code)
+
+        session_id = None
+        if message is not None:
+            try:
+                session_id = SessionManager.get(message).session_id
+            except Exception:
+                session_id = None
+
+        return {
+            "supported_playback_types": {str(p) for p in supported},
+            "blocked_genres": {str(g) for g in blocked},
+            "region": region,
+            "session_id": session_id,
+        }
+
+    @staticmethod
+    def _safe_search(provider, signals, lang, **context):
+        """Call ``provider.search`` so one provider raising cannot abort the
+        multi-provider search, and cannot empty out the legacy bus results it
+        runs alongside. Returns ``[]`` on any exception. ``**context`` carries
+        the explicit MediaProvider kwargs (``supported_playback_types``,
+        ``blocked_genres``, ``region``, ``session_id``)."""
+        try:
+            return provider.search(signals, lang=lang, **context) or []
+        except Exception:
+            LOG.exception(f"MediaProvider '{getattr(provider, 'name', provider)}' "
+                          f"search failed")
+            return []
+
+    def _search_providers(self, phrase: str, media_type: MediaType,
+                          lang: str,
+                          message: Optional[Message] = None) -> RawResultsList:
+        """Dispatch the query to in-process MediaProvider plugins.
+
+        This is the second window of the dual-window search: it runs
+        alongside (not instead of) the legacy bus @ocp_search flow in
+        :meth:`_execute_query`. Builds a :class:`mediavocab.Signals` from the
+        classified media type and query, then runs every loaded provider
+        concurrently through a thread pool calling :meth:`_safe_search`
+        (which never raises -- a provider exception is caught/logged and
+        contributes no results, it cannot empty out the legacy window). Each
+        provider receives the query ``Signals``, ``lang`` and the
+        request-context kwargs from :meth:`_build_query_context`; a provider
+        that cannot serve the query/context returns ``[]``. Each returned
+        ``mediavocab.Release`` is bridged to the OCP playback result dict and
+        added to the result pool by :meth:`_merge_provider_results`.
+
+        Providers blacklisted for the Session (``blacklisted_skills``) are
+        not dispatched to at all: a provider's registry name IS its
+        ``skill_id`` downstream, so the same Session gate that suppresses a
+        bus skill suppresses the provider of that name.
+
+        The whole dispatch is bounded by the pipeline's ``max_timeout``
+        (the same budget the legacy bus window uses): providers still running
+        when it expires are cancelled and contribute nothing, so one slow
+        provider cannot stall the search.
+
+        Returns an empty list (a guaranteed no-op) when no providers are
+        installed/enabled -- this is what keeps the zero-providers case
+        bit-identical to the legacy-only behaviour.
+        """
+        if not self.media_providers:
+            return []
+
+        targets = dict(self.media_providers)
+        if message is not None:
+            try:
+                sess = SessionManager.get(message)
+                blacklist = set(sess.blacklisted_skills or [])
+            except Exception:
+                blacklist = set()
+            if blacklist:
+                skipped = [n for n in targets if n in blacklist]
+                for n in skipped:
+                    targets.pop(n)
+                if skipped:
+                    LOG.debug(f"MediaProviders blacklisted by Session: {skipped}")
+        if not targets:
+            return []
+
+        # Build a minimal provider-ready Signals from the classified media
+        # type and the free-text query via the local bridge.
+        signals = media_type_to_signals(media_type, phrase)
+        context = self._build_query_context(lang, message=message)
+
+        LOG.debug(f"dispatching to {len(targets)} MediaProviders: {list(targets)}")
+        max_timeout = self.config.get("max_timeout", 15)
+
+        results: RawResultsList = []
+        executor = ThreadPoolExecutor(max_workers=len(targets))
+        try:
+            futures = {
+                executor.submit(self._safe_search, p, signals, lang, **context): name
+                for name, p in targets.items()
+            }
+            try:
+                for fut in as_completed(futures, timeout=max_timeout):
+                    name = futures[fut]
+                    try:
+                        releases = fut.result() or []
+                    except Exception:
+                        LOG.exception(f"MediaProvider '{name}' search failed")
+                        continue
+                    for release in releases:
+                        try:
+                            # media_type: stamp the QUERY's legacy media type,
+                            # not the fold of the Release's own -- the fold is
+                            # not injective (NEWS -> RADIO -> RADIO) and
+                            # filter_results would drop the result.
+                            results.append(release_to_ocp_result(
+                                release, name, media_type=media_type,
+                                signals=signals))
+                        except Exception:
+                            LOG.exception(f"failed to bridge result from '{name}'")
+            except FuturesTimeoutError:
+                pending = [n for f, n in futures.items() if not f.done()]
+                LOG.warning(f"MediaProvider search timed out after "
+                            f"{max_timeout}s, dropping: {pending}")
+        finally:
+            # do NOT use the `with` block: its __exit__ joins every worker
+            # thread, which would re-introduce the very stall the timeout
+            # exists to prevent.
+            executor.shutdown(wait=False, cancel_futures=True)
+        LOG.debug(f"MediaProviders returned {len(results)} results")
+        return results
+
+    @staticmethod
+    def _canonical_uri(uri) -> Optional[str]:
+        """Canonical form of a URI, for cross-window de-duplication only.
+
+        Normalizes away the differences that make the same stream look like
+        two: ``http`` vs ``https``, host case, and trailing slashes. Anything
+        else (query string, path case, port) is left alone -- it can select a
+        different resource.
+        """
+        if not uri:
+            return None
+        raw = str(uri).strip()
+        if not raw:
+            return None
+        try:
+            parts = urlsplit(raw)
+        except ValueError:
+            return raw.rstrip("/")
+        if not parts.scheme:
+            return raw.rstrip("/") or None
+        scheme = parts.scheme.lower()
+        if scheme == "https":
+            # http/https is not a different resource for de-dup purposes
+            scheme = "http"
+        return urlunsplit((scheme, parts.netloc.casefold(),
+                           parts.path.rstrip("/"), parts.query, parts.fragment))
+
+    @staticmethod
+    def _carries_playlist(item) -> bool:
+        """True when a result is (or carries) a playlist rather than a single
+        stream. Playlists are never de-duplicated: they aggregate tracks, so a
+        uri match says nothing about the entries being equivalent."""
+        if isinstance(item, Playlist):
+            return True
+        if isinstance(item, dict):
+            return bool(item.get("playlist") or item.get("tracks"))
+        return bool(getattr(item, "playlist", None) or getattr(item, "tracks", None))
+
+    @classmethod
+    def _merge_provider_results(cls, bus_results: list,
+                                provider_results: list) -> list:
+        """Add the in-process MediaProvider window to the legacy bus window.
+
+        Dual-window means BOTH windows contribute. A provider result is
+        **added** to the result pool; it never replaces or deletes a legacy
+        bus entry. The only de-duplication is in the provider -> pool
+        direction: a provider entry is dropped when a legacy entry already
+        covers the same canonical ``uri`` (see :meth:`_canonical_uri`).
+
+        There is deliberately **no** ``(title, artist)`` de-duplication tier:
+        real data falsifies it (a SomaFM bus skill answers artist ``SomaFM``
+        with a stream uri while the provider answers artist ``""`` with a
+        playlist uri -- nothing legitimately collapses), and distinct Releases
+        of one Work are meant to coexist. Entries carrying a playlist are
+        never de-duplicated at all.
+
+        Ranking between the surviving entries is NOT decided here: the
+        existing ``normalize_results`` -> ``filter_results`` -> ``select_best``
+        pipeline arbitrates provider and bus answers exactly as it already
+        arbitrates two competing skills.
+
+        When ``provider_results`` is empty this is a no-op returning
+        ``bus_results`` unchanged -- callers should skip calling it entirely
+        in that case (see :meth:`_search`), so the zero-providers path never
+        even constructs a new list.
+        """
+        def _get(item, key):
+            return item.get(key) if isinstance(item, dict) else getattr(item, key, None)
+
+        merged = list(bus_results)
+        legacy_uris = set()
+        for item in bus_results:
+            if cls._carries_playlist(item):
+                continue
+            canon = cls._canonical_uri(_get(item, "uri"))
+            if canon:
+                legacy_uris.add(canon)
+
+        for prov_item in provider_results:
+            if not cls._carries_playlist(prov_item):
+                canon = cls._canonical_uri(_get(prov_item, "uri"))
+                if canon and canon in legacy_uris:
+                    LOG.debug(f"dropping provider result already covered by a "
+                              f"legacy result: {canon}")
+                    continue
+            merged.append(prov_item)
+        return merged
+
     def _search(self, phrase: str, media_type: MediaType, lang: str,
                 skills: Optional[List[str]] = None,
                 message: Optional[Message] = None) -> list:
         self.bus.emit(message.reply("ovos.common_play.search.start"))
         self.enclosure.mouth_think()  # animate mk1 mouth during search
 
-        # Now we place a query on the messsagebus for anyone who wants to
-        # attempt to service a 'play.request' message.
+        # Legacy window: place a query on the messagebus for anyone who wants
+        # to attempt to service a 'play.request' message.
         results = []
         for r in self._execute_query(phrase,
                                      media_type=media_type,
                                      skills=skills,
                                      message=message):
             results += r["results"]
+
+        # In-process MediaProvider window: runs ALONGSIDE the legacy bus
+        # window above, never instead of it. Its results are ADDED to the
+        # pool -- a legacy result is never replaced or deleted. Skill-targeted
+        # searches (user named a specific OCP skill) stay bus-only. When no
+        # providers are installed/loaded, `_search_providers` is a guaranteed
+        # no-op and `_merge_provider_results` is skipped entirely -- `results`
+        # is exactly the legacy bus list, unmodified, so output is
+        # bit-identical to the pre-existing legacy-only behaviour.
+        if not skills:
+            provider_results = self._search_providers(phrase, media_type, lang,
+                                                      message=message)
+            if provider_results:
+                results = self._merge_provider_results(results, provider_results)
 
         results = self.normalize_results(results)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,18 @@ test = [
     "flake8>=3.7.9",
     "pytest>=5.2.4",
     "pytest-cov>=2.8.1",
-    "cov-core>=1.15.0"
+    "cov-core>=1.15.0",
+    # exercise the in-process MediaProvider dispatch path in tests too
+    "mediavocab>=1.1.0,<2.0.0",
+    "ovos-plugin-manager>=2.11.1a2,<3.0.0"
+]
+# opt-in: in-process MediaProvider dispatch (opm.media.provider). Without this
+# extra installed, ocp_pipeline.bridge / the MediaProvider import both raise
+# ImportError and the pipeline transparently degrades to the legacy
+# bus-only @ocp_search flow -- this is the back-compat guarantee.
+media = [
+    "mediavocab>=1.1.0,<2.0.0",
+    "ovos-plugin-manager>=2.11.1a2,<3.0.0"
 ]
 
 [project.urls]

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -1,0 +1,127 @@
+"""Unit tests for ocp_pipeline.bridge (mediavocab <-> legacy ocp.MediaType).
+
+``mediavocab`` and the ``MediaProvider`` plugin type are optional deps: skip
+this whole module when unavailable rather than failing the suite.
+"""
+import unittest
+
+from ovos_utils.ocp import MediaType as OCPMediaType
+from ovos_utils.ocp import PlaybackType as OCPPlaybackType
+
+try:
+    import mediavocab
+    from mediavocab import EntityKind, MediaType as MVMediaType, Release, Work
+    from mediavocab.models.entity import Credit, EntityRef
+    from mediavocab.taxonomy import PlaybackType as MVPlaybackType
+    HAS_MEDIAVOCAB = True
+except ImportError:
+    HAS_MEDIAVOCAB = False
+
+from ocp_pipeline import bridge
+
+
+def _make_release(title, media_type, uri, conf, artist="", runtime=0):
+    credits = []
+    if artist:
+        credits = [Credit(entity=EntityRef(name=artist, kind=EntityKind.GROUP),
+                          role="artist")]
+    work = Work(title=title, media_type=media_type, runtime=runtime,
+               credits=credits)
+    return Release(work=work, uri=uri, image=f"{title}.png", match_confidence=conf)
+
+
+@unittest.skipUnless(HAS_MEDIAVOCAB, "mediavocab not installed")
+class TestBridge(unittest.TestCase):
+    def test_release_to_ocp_result_fields(self):
+        rel = _make_release("Black Album", MVMediaType.MUSIC,
+                            "https://music/black", 0.85, artist="Metallica",
+                            runtime=3600)
+        d = bridge.release_to_ocp_result(rel, "mock.music")
+        self.assertEqual(d["uri"], "https://music/black")
+        self.assertEqual(d["title"], "Black Album")
+        self.assertEqual(d["artist"], "Metallica")
+        self.assertEqual(d["length"], 3600)
+        # media_type is folded back to the legacy ovos_utils.ocp taxonomy
+        self.assertEqual(d["media_type"], OCPMediaType.MUSIC)
+        self.assertEqual(d["playback"], OCPPlaybackType.AUDIO)
+        self.assertEqual(d["match_confidence"], 85)
+        self.assertEqual(d["skill_id"], "mock.music")
+
+    def test_confidence_clamped_and_scaled(self):
+        rel = _make_release("x", MVMediaType.MUSIC, "u", 1.0)
+        self.assertEqual(bridge.release_to_ocp_result(rel, "p")["match_confidence"], 100)
+        rel0 = _make_release("x", MVMediaType.MUSIC, "u", 0.0)
+        self.assertEqual(bridge.release_to_ocp_result(rel0, "p")["match_confidence"], 0)
+
+    def test_no_credit_artist_empty(self):
+        rel = _make_release("x", MVMediaType.MOVIE, "u", 0.5)
+        self.assertEqual(bridge.release_to_ocp_result(rel, "p")["artist"], "")
+
+    def test_playback_type_mapping(self):
+        self.assertEqual(bridge.mediavocab_playback_to_ocp(MVPlaybackType.AUDIO),
+                         OCPPlaybackType.AUDIO)
+        self.assertEqual(bridge.mediavocab_playback_to_ocp(MVPlaybackType.VIDEO),
+                         OCPPlaybackType.VIDEO)
+        self.assertEqual(bridge.mediavocab_playback_to_ocp(MVPlaybackType.INTERACTIVE),
+                         OCPPlaybackType.SKILL)
+        self.assertEqual(bridge.mediavocab_playback_to_ocp(MVPlaybackType.PAGED),
+                         OCPPlaybackType.WEBVIEW)
+
+    def test_media_type_to_signals_music(self):
+        sig = bridge.media_type_to_signals(OCPMediaType.MUSIC, "metallica")
+        self.assertEqual(sig.medium, MVMediaType.MUSIC)
+        self.assertEqual(sig.title, "metallica")
+
+    def test_media_type_to_signals_generic_is_typeless(self):
+        sig = bridge.media_type_to_signals(OCPMediaType.GENERIC, "anything")
+        self.assertIsNone(sig.medium)
+
+    def test_ocp_to_mediavocab_movie(self):
+        self.assertEqual(bridge.ocp_media_type_to_mediavocab(OCPMediaType.MOVIE),
+                         MVMediaType.MOVIE)
+
+    def test_mediavocab_to_ocp_roundtrip_music(self):
+        self.assertEqual(bridge.mediavocab_media_type_to_ocp(MVMediaType.MUSIC),
+                         OCPMediaType.MUSIC)
+
+    def test_mediavocab_unmapped_falls_back_to_generic(self):
+        self.assertEqual(bridge.mediavocab_media_type_to_ocp(MVMediaType.PLAYLIST),
+                         OCPMediaType.GENERIC)
+
+    def test_media_type_override_wins(self):
+        """Callers stamp the QUERY's legacy media type: the mediavocab fold is
+        not injective (NEWS -> RADIO -> RADIO)."""
+        rel = _make_release("BBC News", MVMediaType.RADIO, "u", 0.9)
+        d = bridge.release_to_ocp_result(rel, "p", media_type=OCPMediaType.NEWS)
+        self.assertEqual(d["media_type"], OCPMediaType.NEWS)
+        # without the override the Release's own type is folded back
+        self.assertEqual(bridge.release_to_ocp_result(rel, "p")["media_type"],
+                         OCPMediaType.RADIO)
+
+    def test_unscored_release_gets_fuzzy_fallback_confidence(self):
+        rel = _make_release("Groove Salad", MVMediaType.RADIO,
+                            "https://somafm.com/groovesalad.pls", 0.0)
+        sig = bridge.media_type_to_signals(OCPMediaType.RADIO, "groove salad")
+        d = bridge.release_to_ocp_result(rel, "somafm", signals=sig)
+        # a good title match must survive the default min_score of 50
+        self.assertGreaterEqual(d["match_confidence"], 50)
+
+    def test_unscored_release_with_bad_title_stays_low(self):
+        rel = _make_release("Totally Unrelated", MVMediaType.RADIO, "u", 0.0)
+        sig = bridge.media_type_to_signals(OCPMediaType.RADIO, "groove salad")
+        d = bridge.release_to_ocp_result(rel, "somafm", signals=sig)
+        self.assertLess(d["match_confidence"], 50)
+
+    def test_provider_score_is_never_overridden(self):
+        rel = _make_release("Totally Unrelated", MVMediaType.RADIO, "u", 0.8)
+        sig = bridge.media_type_to_signals(OCPMediaType.RADIO, "groove salad")
+        d = bridge.release_to_ocp_result(rel, "somafm", signals=sig)
+        self.assertEqual(d["match_confidence"], 80)
+
+    def test_fallback_without_signals_is_zero(self):
+        rel = _make_release("Groove Salad", MVMediaType.RADIO, "u", 0.0)
+        self.assertEqual(bridge.release_to_ocp_result(rel, "p")["match_confidence"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_media_provider_dispatch.py
+++ b/test/test_media_provider_dispatch.py
@@ -1,0 +1,454 @@
+"""Tests for the in-process MediaProvider dispatch + additive dual-window merge.
+
+Follows the ``__new__``-bypass pattern used across ``test/test_pipeline.py``:
+``OCPPipelineMatcher.__init__`` is heavy (bus/intents/padatious), so these
+tests construct a bare instance and inject only the attributes the methods
+under test actually read.
+
+Covers the guarantees the design ruling requires:
+
+1. Zero MediaProviders installed -> ``_search`` output is identical to the
+   legacy-only bus path (the back-compat guarantee).
+2. Provider results are ADDED to the pool; a legacy bus entry is never
+   replaced or deleted. The only de-dup is provider -> pool, by canonical uri.
+3. A provider raising during ``search`` does not break or empty out the
+   legacy bus results.
+4. A slow provider cannot stall the search past ``max_timeout``.
+5. The provider query context comes from the GLOBAL config, not the pipeline
+   sub-config.
+6. Provider results carry the QUERY's legacy media type, so ``filter_results``
+   does not drop them when the mediavocab fold is not injective (NEWS).
+7. Session ``blacklisted_skills`` suppresses a provider of that name.
+8. Real-shape SomaFM coexistence: the bus answer and the provider answer both
+   survive all the way to ``select_best``.
+"""
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import MediaType, PlaybackType
+
+from ocp_pipeline.opm import OCPPipelineMatcher
+
+try:
+    from mediavocab import MediaType as MVMediaType, Release, Work
+    HAS_MEDIAVOCAB = True
+except ImportError:
+    HAS_MEDIAVOCAB = False
+
+
+def _make_pipeline(media_providers=None):
+    """Create OCPPipelineMatcher bypassing its __init__."""
+    p = OCPPipelineMatcher.__new__(OCPPipelineMatcher)
+    p.bus = FakeBus()
+    p.ocp_sessions = {}
+    p.skill_aliases = {}
+    p.media2skill = {m: [] for m in MediaType}
+    p.config = {}
+    p.media_providers = media_providers or {}
+    return p
+
+
+def _wire_search(p, bus_track, config=None):
+    """Wire the collaborators `_search` needs, with a single legacy result."""
+    p.search_lock = MagicMock()
+    p.search_lock.__enter__ = MagicMock(return_value=None)
+    p.search_lock.__exit__ = MagicMock(return_value=None)
+    p._enclosure = MagicMock()
+    p.config = config if config is not None else {"filter_media": False,
+                                                  "filter_SEI": False,
+                                                  "min_score": 0}
+    p._execute_query = MagicMock(return_value=[{"results": [dict(bus_track)]}])
+    p.normalize_results = MagicMock(side_effect=lambda r: r)
+    p.filter_results = MagicMock(side_effect=lambda r, *a, **kw: r)
+    p.get_player = MagicMock()
+    return p
+
+
+def _message(session_id="s1", blacklist=None):
+    sess = {"session_id": session_id}
+    if blacklist is not None:
+        sess["blacklisted_skills"] = blacklist
+    return Message("recognizer_loop:utterance", {}, {"session": sess})
+
+
+def _bus_track(uri, title, artist="", confidence=50):
+    return {"uri": uri, "title": title, "artist": artist,
+            "media_type": int(MediaType.MUSIC), "playback": 2,
+            "match_confidence": confidence, "skill_id": "bus.skill"}
+
+
+def _provider_result(uri, title, artist="", confidence=90, skill_id="mock.provider"):
+    return {"uri": uri, "title": title, "artist": artist, "image": "",
+            "length": 0, "media_type": MediaType.MUSIC, "playback": 2,
+            "match_confidence": confidence, "skill_id": skill_id}
+
+
+def _release(title, media_type, uri, conf=None):
+    work = Work(title=title, media_type=media_type)
+    kwargs = {}
+    if conf is not None:
+        kwargs["match_confidence"] = conf
+    return Release(work=work, uri=uri, image="", **kwargs)
+
+
+def _provider(name, releases=(), delay=0.0, raises=None):
+    prov = MagicMock()
+    prov.name = name
+
+    def _search(*args, **kwargs):
+        if delay:
+            time.sleep(delay)
+        if raises:
+            raise raises
+        return list(releases)
+
+    prov.search.side_effect = _search
+    return prov
+
+
+# ---------------------------------------------------------------------------
+# 1. Back-compat guarantee: zero providers -> bit-identical to legacy-only
+# ---------------------------------------------------------------------------
+
+class TestZeroProvidersBackCompat(unittest.TestCase):
+    def test_search_providers_is_noop_with_no_providers(self):
+        p = _make_pipeline(media_providers={})
+        self.assertEqual(
+            p._search_providers("play metallica", MediaType.MUSIC, "en-us"), [])
+
+    def test_search_matches_legacy_only_output_when_no_providers(self):
+        """`_search` with an empty `media_providers` dict must produce exactly
+        the same `results` list (same objects, same order) that the
+        pre-existing legacy-only implementation would have -- i.e. the merge
+        step must never even run."""
+        p = _wire_search(_make_pipeline(media_providers={}),
+                         _bus_track("http://x.com/a.mp3", "Song A"))
+        bus_track = _bus_track("http://x.com/a.mp3", "Song A")
+
+        results = p._search("play song a", MediaType.MUSIC, "en-us",
+                            message=_message())
+
+        # exactly the legacy bus result, unmodified -- no provider dispatch,
+        # no merge, bit-identical to the pre-change behaviour.
+        self.assertEqual(results, [bus_track])
+
+    def test_load_media_providers_respects_enabled_flag(self):
+        p = _make_pipeline()
+        p.config = {"media_providers": {"enabled": False}}
+        with patch("ocp_pipeline.opm.load_media_providers") as loader:
+            p._load_media_providers()
+        loader.assert_not_called()
+        self.assertEqual(p.media_providers, {})
+
+    def test_load_media_providers_enabled_by_default(self):
+        p = _make_pipeline()
+        p.config = {}
+        with patch("ocp_pipeline.opm.load_media_providers",
+                   return_value={"x": MagicMock()}) as loader:
+            p._load_media_providers()
+        loader.assert_called_once()
+        self.assertEqual(list(p.media_providers), ["x"])
+
+
+# ---------------------------------------------------------------------------
+# 2. Additive merge: provider results are ADDED, never replace a legacy entry
+# ---------------------------------------------------------------------------
+
+class TestAdditiveMerge(unittest.TestCase):
+    def test_provider_result_appended_when_no_collision(self):
+        p = _make_pipeline()
+        bus_results = [_bus_track("http://bus/1", "Bus Track")]
+        provider_results = [_provider_result("http://prov/1", "Provider Track")]
+        merged = p._merge_provider_results(bus_results, provider_results)
+        self.assertEqual(len(merged), 2)
+        self.assertEqual({r["uri"] for r in merged},
+                         {"http://bus/1", "http://prov/1"})
+
+    def test_legacy_entry_is_never_replaced_on_uri_collision(self):
+        """The provider entry is DROPPED; the legacy entry stays untouched."""
+        p = _make_pipeline()
+        bus = _bus_track("http://same/uri", "Old Title", confidence=40)
+        provider_results = [_provider_result("http://same/uri", "New Title",
+                                             confidence=95)]
+        merged = p._merge_provider_results([bus], provider_results)
+        self.assertEqual(merged, [bus])
+        self.assertEqual(merged[0]["skill_id"], "bus.skill")
+
+    def test_uri_dedup_is_canonical(self):
+        p = _make_pipeline()
+        bus = _bus_track("http://Example.COM/Track/", "Track")
+        for dupe in ("https://example.com/Track",
+                     "http://example.com/Track/",
+                     "HTTPS://EXAMPLE.com/Track/"):
+            merged = p._merge_provider_results(
+                [bus], [_provider_result(dupe, "Track")])
+            self.assertEqual(merged, [bus], dupe)
+
+    def test_same_title_artist_different_uri_both_survive(self):
+        """No (title, artist) de-dup tier: distinct Releases of one Work
+        legitimately coexist."""
+        p = _make_pipeline()
+        bus = _bus_track("http://bus/uri", "Same Song", artist="Metallica")
+        prov = _provider_result("http://provider/uri", "Same Song",
+                                artist="Metallica")
+        merged = p._merge_provider_results([bus], [prov])
+        self.assertEqual(merged, [bus, prov])
+
+    def test_playlist_entries_are_never_deduplicated(self):
+        p = _make_pipeline()
+        bus = {"title": "Mix", "uri": "http://same/uri",
+               "playlist": [{"uri": "http://a", "title": "a"}],
+               "match_confidence": 50, "skill_id": "bus.skill"}
+        prov = {"title": "Mix", "uri": "http://same/uri",
+                "playlist": [{"uri": "http://b", "title": "b"}],
+                "match_confidence": 90, "skill_id": "mock.provider"}
+        merged = p._merge_provider_results([bus], [prov])
+        self.assertEqual(merged, [bus, prov])
+
+    def test_empty_provider_results_returns_bus_results_unchanged(self):
+        p = _make_pipeline()
+        bus_results = [_bus_track("http://bus/uri", "Song")]
+        merged = p._merge_provider_results(bus_results, [])
+        self.assertEqual(merged, bus_results)
+
+    def test_search_providers_dispatches_to_registered_provider(self):
+        prov = _provider("mock.provider")
+        p = _make_pipeline(media_providers={"mock.provider": prov})
+        p._search_providers("play something", MediaType.GENERIC, "en-us")
+        self.assertTrue(prov.search.called)
+
+
+# ---------------------------------------------------------------------------
+# 3. A raising provider must not break or empty out legacy bus results
+# ---------------------------------------------------------------------------
+
+class TestProviderExceptionIsolation(unittest.TestCase):
+    def test_safe_search_absorbs_exception(self):
+        provider = _provider("boom.provider", raises=RuntimeError("boom"))
+        result = OCPPipelineMatcher._safe_search(provider, "signals", "en-us")
+        self.assertEqual(result, [])
+
+    def test_raising_provider_does_not_empty_dispatch_results(self):
+        good = _provider("good.provider")
+        boom = _provider("boom.provider", raises=RuntimeError("boom"))
+        p = _make_pipeline(media_providers={"boom.provider": boom,
+                                            "good.provider": good})
+        results = p._search_providers("play something", MediaType.GENERIC,
+                                      "en-us")
+        self.assertEqual(results, [])
+        self.assertTrue(boom.search.called)
+        self.assertTrue(good.search.called)
+
+    def test_raising_provider_does_not_break_full_search_bus_results_survive(self):
+        boom = _provider("boom.provider", raises=RuntimeError("boom"))
+        p = _wire_search(_make_pipeline(media_providers={"boom.provider": boom}),
+                         _bus_track("http://x.com/a.mp3", "Legacy Song"))
+        bus_track = _bus_track("http://x.com/a.mp3", "Legacy Song")
+        results = p._search("play legacy song", MediaType.MUSIC, "en-us",
+                            message=_message())
+        self.assertEqual(results, [bus_track])
+
+
+# ---------------------------------------------------------------------------
+# 4. A slow provider cannot stall the search past max_timeout
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(HAS_MEDIAVOCAB, "mediavocab not installed")
+class TestDispatchTimeout(unittest.TestCase):
+    def test_slow_provider_is_dropped_at_max_timeout(self):
+        fast = _provider("fast.provider",
+                         releases=[_release("Fast Song", MVMediaType.MUSIC,
+                                            "http://fast/1", conf=0.9)])
+        slow = _provider("slow.provider", delay=3.0,
+                         releases=[_release("Slow Song", MVMediaType.MUSIC,
+                                            "http://slow/1", conf=0.9)])
+        p = _make_pipeline(media_providers={"fast.provider": fast,
+                                            "slow.provider": slow})
+        p.config = {"max_timeout": 1}
+
+        # warm up the config/signals machinery so the measurement below times
+        # the dispatch, not a first-call import
+        warm = _make_pipeline(media_providers={"fast.provider": fast})
+        warm.config = {"max_timeout": 1}
+        warm._search_providers("fast song", MediaType.MUSIC, "en-us")
+
+        start = time.monotonic()
+        results = p._search_providers("fast song", MediaType.MUSIC, "en-us")
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 1.5,
+                        f"search stalled on the slow provider ({elapsed:.2f}s)")
+        self.assertEqual([r["title"] for r in results], ["Fast Song"])
+
+
+# ---------------------------------------------------------------------------
+# 5. Query context comes from the GLOBAL config
+# ---------------------------------------------------------------------------
+
+class TestQueryContext(unittest.TestCase):
+    GLOBAL = {
+        "media": {"supported_playback_types": ["audio", "video"]},
+        "media_content_filter": {"blocked_genres": ["adult", "horror"]},
+        "location": {"city": {"region": {"country": {"code": "PT"}}}},
+    }
+
+    def test_context_is_read_from_global_config(self):
+        p = _make_pipeline()
+        # the pipeline sub-config carries none of these keys
+        p.config = {"min_score": 50}
+        with patch("ocp_pipeline.opm.Configuration", return_value=dict(self.GLOBAL)):
+            ctx = p._build_query_context("en-us", message=_message("sess-42"))
+        self.assertEqual(ctx["supported_playback_types"], {"audio", "video"})
+        self.assertEqual(ctx["blocked_genres"], {"adult", "horror"})
+        self.assertEqual(ctx["region"], "PT")
+        self.assertEqual(ctx["session_id"], "sess-42")
+
+    def test_context_defaults_are_permissive_but_block_adult(self):
+        p = _make_pipeline()
+        p.config = {}
+        with patch("ocp_pipeline.opm.Configuration", return_value={}):
+            ctx = p._build_query_context("en-us")
+        self.assertEqual(ctx["supported_playback_types"], set())
+        self.assertEqual(ctx["blocked_genres"], {"adult"})
+        self.assertIsNone(ctx["region"])
+        self.assertIsNone(ctx["session_id"])
+
+    def test_allow_adult_content_unblocks_adult(self):
+        p = _make_pipeline()
+        p.config = {}
+        cfg = {"media_content_filter": {"allow_adult_content": True}}
+        with patch("ocp_pipeline.opm.Configuration", return_value=cfg):
+            ctx = p._build_query_context("en-us")
+        self.assertEqual(ctx["blocked_genres"], set())
+
+
+# ---------------------------------------------------------------------------
+# 6. MediaType round-trip: provider results carry the QUERY's media type
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(HAS_MEDIAVOCAB, "mediavocab not installed")
+class TestMediaTypeRoundTrip(unittest.TestCase):
+    def test_news_query_results_survive_filter_results(self):
+        """legacy NEWS folds onto mediavocab RADIO, which folds back to legacy
+        RADIO -- stamping the Release's own type would make filter_results
+        drop every provider answer to a NEWS query."""
+        prov = _provider("news.provider",
+                         releases=[_release("BBC World Service",
+                                            MVMediaType.RADIO,
+                                            "http://news/stream.mp3",
+                                            conf=0.9)])
+        p = _make_pipeline(media_providers={"news.provider": prov})
+        p.config = {"min_score": 50, "filter_media": True, "filter_SEI": True}
+
+        results = p._search_providers("the news", MediaType.NEWS, "en-us")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["media_type"], MediaType.NEWS)
+
+        player = MagicMock()
+        player.available_extractors = []
+        player.ocp_available = True
+        p.get_player = MagicMock(return_value=player)
+        kept = p.filter_results(p.normalize_results(results), "the news",
+                                "en-us", MediaType.NEWS, message=_message())
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(kept[0].media_type, MediaType.NEWS)
+
+
+# ---------------------------------------------------------------------------
+# 7. Session blacklist suppresses a provider of the same name
+# ---------------------------------------------------------------------------
+
+class TestSessionBlacklist(unittest.TestCase):
+    def test_blacklisted_provider_is_not_dispatched_to(self):
+        blocked = _provider("somafm")
+        other = _provider("other.provider")
+        p = _make_pipeline(media_providers={"somafm": blocked,
+                                            "other.provider": other})
+        p.config = {}
+        p._search_providers("play groove salad", MediaType.RADIO, "en-us",
+                            message=_message(blacklist=["somafm"]))
+        self.assertFalse(blocked.search.called)
+        self.assertTrue(other.search.called)
+
+    def test_no_blacklist_dispatches_to_all(self):
+        prov = _provider("somafm")
+        p = _make_pipeline(media_providers={"somafm": prov})
+        p.config = {}
+        p._search_providers("play groove salad", MediaType.RADIO, "en-us",
+                            message=_message())
+        self.assertTrue(prov.search.called)
+
+
+# ---------------------------------------------------------------------------
+# 8. Real-shape coexistence, merged -> normalize -> filter -> select_best
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(HAS_MEDIAVOCAB, "mediavocab not installed")
+class TestSomaFMCoexistence(unittest.TestCase):
+    """Recorded shapes from the real ecosystem: the skill answers with a
+    direct stream uri, artist "SomaFM", confidence 95; the provider answers
+    with a .pls playlist uri, no credited artist, and no confidence at all.
+    Nothing may collapse and nothing may be dropped."""
+
+    SKILL_RESULT = {"uri": "http://ice2.somafm.com/groovesalad-128-mp3",
+                    "title": "Groove Salad",
+                    "artist": "SomaFM",
+                    "media_type": MediaType.RADIO,
+                    "playback": PlaybackType.AUDIO,
+                    "match_confidence": 95,
+                    "skill_id": "skill-somafm.openvoiceos"}
+
+    def test_both_windows_survive_to_select_best(self):
+        release = _release("Groove Salad", MVMediaType.RADIO,
+                           "https://somafm.com/groovesalad.pls")
+        self.assertFalse(release.match_confidence,
+                         "fixture must be an UNSCORED provider release")
+        prov = _provider("somafm", releases=[release])
+        p = _make_pipeline(media_providers={"somafm": prov})
+        p.config = {"min_score": 50, "filter_media": True, "filter_SEI": True}
+
+        provider_results = p._search_providers("groove salad", MediaType.RADIO,
+                                               "en-us")
+        self.assertEqual(len(provider_results), 1)
+        # the unscored release was scored by the bridge fallback, so min_score
+        # cannot kill it
+        self.assertGreaterEqual(provider_results[0]["match_confidence"], 50)
+
+        merged = p._merge_provider_results([dict(self.SKILL_RESULT)],
+                                           provider_results)
+        self.assertEqual(len(merged), 2, "different uris must NOT collapse")
+
+        player = MagicMock()
+        player.available_extractors = []
+        player.ocp_available = True
+        p.get_player = MagicMock(return_value=player)
+
+        kept = p.filter_results(p.normalize_results(merged), "groove salad",
+                                "en-us", MediaType.RADIO, message=_message())
+        self.assertEqual(len(kept), 2, "both windows must reach select_best")
+        self.assertEqual({r.skill_id for r in kept},
+                         {"skill-somafm.openvoiceos", "somafm"})
+
+        # arbitration is the EXISTING pipeline's, unchanged: here the exact
+        # title match scores the provider 100 against the skill's own 95.
+        best = p.select_best(kept, _message())
+        self.assertEqual(best.skill_id, "somafm")
+        self.assertEqual(best.match_confidence, 100)
+
+    def test_blacklisting_the_provider_leaves_the_skill_result(self):
+        release = _release("Groove Salad", MVMediaType.RADIO,
+                           "https://somafm.com/groovesalad.pls")
+        prov = _provider("somafm", releases=[release])
+        p = _make_pipeline(media_providers={"somafm": prov})
+        p.config = {"min_score": 50}
+        provider_results = p._search_providers(
+            "groove salad", MediaType.RADIO, "en-us",
+            message=_message(blacklist=["somafm"]))
+        self.assertEqual(provider_results, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This re-opens a design the maintainer had previously closed as PR #137 and PR #138. It's re-opened at the maintainer's explicit request, made today in conversation, specifically asking to revisit the decision on dispatching to in-process MediaProvider plugins from the pipeline. It's based on #138, the CI-green variant without private dependencies — #137 additionally migrated media-type classification onto a different taxonomy, which is out of scope here and is now tracked separately by the open, classification-only PRs #142 and #143. This PR does not touch media-type classification at all; that stays exactly as it is on dev today.

It's also been updated to match the current MediaProvider contract from ovos-plugin-manager's dev branch, which changed since #138 was written, and it's loaded in bulk the same way that package now expects.

The maintainer's decision here, not something I chose, is that this should merge two results together rather than replace one with the other. The new in-process provider dispatch runs alongside the existing legacy bus search flow, not instead of it — both run whenever a search isn't explicitly targeted at skills only. No bus message types change, and the legacy path is never gated off or removed. Provider results only ever get added to the pool; a legacy result is never replaced, deleted, or reordered. The only place de-duplication happens is dropping a provider entry when a legacy entry already covers the same URI, once both are normalized to a canonical form — same scheme folded, host lowercased, trailing slashes stripped. Anything carrying a playlist is never de-duplicated, since a URI match says nothing meaningful there. Ranking itself isn't decided in this merge step at all — the existing scoring pipeline treats a provider answer exactly like it already treats two competing skill answers. And when no MediaProvider plugins are installed or loaded at all, which is the default, the provider search returns immediately with nothing and the merge step is never even called, so the result list is byte-identical to the legacy-only behavior — this is covered by its own dedicated test. There's also a config flag to disable the whole feature outright, on by default.

Compared to the original #138 diff: the media-type classification migration is dropped entirely, since that's now its own separate decision tracked elsewhere. The merge logic changed from appending provider results with no de-duplication at all to the explicit, canonical-URI-based de-duplication described above. A new two-way bridge module was added to translate between the newer taxonomy and the legacy one the pipeline still classifies on, since #138's bridge only went one direction. The core dispatch mechanism itself — loading providers, building a permissive query context, wrapping calls so one provider's exception can't take down the others, dispatching them concurrently with a thread pool, and gracefully degrading when the optional dependencies aren't installed — is kept from #138 largely as-is. And the two new optional dependencies are now real PyPI releases rather than git installs, and they're added as an optional extra, not a hard requirement, so the base package still has no new mandatory dependency.

Full suite in a throwaway venv: 99 passed, 0 failed, 0 skipped — 62 pre-existing tests plus 37 new ones. Every behavioral change here is proven necessary: each one was reverted in the working tree and confirmed the guarding test actually fails before being restored.

Two independent reviews, one for correctness and one for backwards compatibility, found real problems, and every one is fixed and covered by its own red-proven test. The merge used to replace a legacy result outright on a URI collision, meaning a working skill's answer could simply vanish — that's fixed by never replacing, only adding. URI matching used to miss simple differences like http versus https or a trailing slash, causing inconsistent de-duplication — it's now canonicalized properly, while leaving query strings, path case, and port alone since those can genuinely point at a different resource. A same-title-and-artist de-duplication rule turned out to be wrong against real data — a skill and a provider can legitimately answer the same query with different artist fields and different URIs, and both should survive — so that rule was removed entirely. Playlists were being de-duplicated the same way as single tracks, which doesn't make sense since a URI match says nothing about what's inside the playlist, so playlists are now never de-duplicated. There was no real timeout on provider dispatch — a single hung provider could stall the whole search — so there's now a proper timeout with pending providers logged and dropped, and the executor is shut down without waiting for stragglers. The context built for providers was reading from config keys the pipeline's own sub-config never actually carries, so it was always empty; it now reads from the global configuration where those settings actually live. The media-type round trip through the bridge wasn't always reversible, so a provider answer to a news query could get silently dropped by the later filtering step — providers now carry the original query's media type instead of a re-derived one. Session-level skill blacklisting was only being applied to legacy bus results, so a blacklisted provider could still answer — providers are now excluded from dispatch entirely if blacklisted. An unscored provider result used to be treated as zero confidence, which the default minimum score always rejects, meaning such a result could never actually be played — there's now a fallback scoring step that fuzzy-matches the result against the query, but only when the provider didn't already supply its own score, since providers should score themselves when they can. And there was no documented way to turn the new feature off — there's now a config flag for that, on by default.

One thing is left as an open question for the maintainer rather than guessed at: a skill and a provider can represent the same underlying service under different ids — for example a skill called skill-somafm.openvoiceos and a provider simply called somafm. Right now, blacklisting is applied by each side's own id only, so blacklisting the skill doesn't suppress the same-named provider. A user who blacklisted the skill might reasonably expect the whole service gone, not have it come back through the provider path. No automatic name-guessing is implemented here on purpose, since inferring that two different ids are "the same thing" from their names is exactly the kind of rule that backfires — this needs an explicit decision from the maintainer, whether that's an alias config, a provider-declared relationship, or leaving it as is.
