### PR TITLE
fix: correct media_type construction and remove non-deterministic tie-break in select_best

### DIFF
--- a/ocp_pipeline/opm.py
+++ b/ocp_pipeline/opm.py
@@ -1,5 +1,4 @@
 import os
-import random
 import threading
 from dataclasses import dataclass
 from os.path import join, dirname, isdir
@@ -308,7 +307,7 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             player.media_state = MediaState(mstate)
             LOG.debug(f"Session: {player.session_id} MediaState: {player.media_state}")
         if mtype is not None:
-            player.media_type = MediaType(pstate)
+            player.media_type = MediaType(mtype)
             LOG.debug(f"Session: {player.session_id} MediaType: {player.media_type}")
         player = self._update_player_skill_id(player, message)
         self.update_player_proxy(player)
@@ -1077,8 +1076,9 @@ class OCPPipelineMatcher(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                 ties.append(res)
 
         if ties:
-            # select randomly
-            selected = random.choice(ties)
+            # deterministic tie-break: keep the first candidate encountered
+            # (previously used random.choice, which made results non-deterministic)
+            selected = ties[0]
             # TODO: Ask user to pick between ties or do it automagically
         else:
             selected = best

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -599,5 +599,97 @@ class TestControlIntentGating(unittest.TestCase):
         self.assertEqual(result.match_type, "ocp:next")
 
 
+# ---------------------------------------------------------------------------
+# handle_player_state_update -> match_high (media_type regression)
+#
+# handle_player_state_update previously built ``player.media_type`` from the
+# player_state ordinal instead of the media_type ordinal in the same status
+# message (MediaType(pstate) instead of MediaType(mtype)). Both bugs below
+# are only visible end-to-end: apply a real status update, then exercise the
+# intent gates in match_high that read player.media_type.
+# ---------------------------------------------------------------------------
+
+class TestMediaTypeFromStatusUpdate(unittest.TestCase):
+
+    def _pipeline_ready_for(self, intent_name):
+        from ocp_pipeline.opm import OCPPlayerProxy
+        p = _make_pipeline()
+        p.config = {"legacy": True}
+        p.skill_aliases = {"ovos-skill-test": ["test"]}
+        p._get_closest_lang = MagicMock(return_value="en-US")
+        matcher = MagicMock()
+        matcher.calc_intent.return_value = {"name": intent_name, "conf": 1.0,
+                                            "entities": {}}
+        p.intent_matchers = {"en-US": matcher}
+        proxy = OCPPlayerProxy(session_id="default", available_extractors=[],
+                               ocp_available=True)
+        p.ocp_sessions["default"] = proxy
+        return p
+
+    def test_like_song_reachable_while_music_playing(self):
+        """While a track is PLAYING (PlayerState.PLAYING == 1) with music
+        active, a status update reporting media_type MUSIC must make
+        like_song reachable, not gate it off because PlayerState.PLAYING's
+        ordinal (1) collides with MediaType.AUDIO's ordinal."""
+        p = self._pipeline_ready_for("like_song")
+        status = _make_message(session_id="default",
+                                data={"player_state": int(PlayerState.PLAYING),
+                                      "media_type": int(MediaType.MUSIC)})
+        p.handle_player_state_update(status)
+        self.assertEqual(p.ocp_sessions["default"].media_type, MediaType.MUSIC)
+
+        msg = _make_message(session_id="default")
+        result = p.match_high(["like_song"], "en-US", msg)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_type, "ocp:like_song")
+
+    def test_game_intents_reachable_while_game_active(self):
+        """MediaType.GAME (5) can never be produced from a PlayerState
+        ordinal (0/1/2 only), so save/load-game gating never engaged. A
+        status update reporting media_type GAME must make save_game
+        reachable."""
+        p = self._pipeline_ready_for("save_game")
+        status = _make_message(session_id="default",
+                                data={"player_state": int(PlayerState.PLAYING),
+                                      "media_type": int(MediaType.GAME)})
+        p.handle_player_state_update(status)
+        self.assertEqual(p.ocp_sessions["default"].media_type, MediaType.GAME)
+
+        msg = _make_message(session_id="default")
+        result = p.match_high(["save_game"], "en-US", msg)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_type, "ocp:save_game")
+
+
+# ---------------------------------------------------------------------------
+# select_best (non-determinism regression)
+# ---------------------------------------------------------------------------
+
+class TestSelectBestDeterministic(unittest.TestCase):
+
+    def test_tie_break_is_deterministic(self):
+        """Ties on match_confidence must always resolve to the same result
+        (previously used random.choice, which could pick a different
+        skill_id on each call)."""
+        from ocp_pipeline.opm import OCPPipelineMatcher
+
+        results = [
+            MediaEntry(uri=f"uri-{i}", title=f"title-{i}", skill_id=f"skill-{i}",
+                      match_confidence=90)
+            for i in range(5)
+        ]
+        msg = _make_message(session_id="default")
+        with patch("ocp_pipeline.opm.SessionManager") as mock_sm:
+            mock_sess = MagicMock()
+            mock_sess.blacklisted_skills = []
+            mock_sm.get.return_value = mock_sess
+
+            winners = {OCPPipelineMatcher.select_best(list(results), msg).skill_id
+                       for _ in range(50)}
+
+        self.assertEqual(len(winners), 1,
+                         f"select_best produced multiple distinct winners on ties: {winners}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Two small, independently verified bugs found during a UX audit of OCP intent handling.

The first: the code that builds the current media type from a status update was reading the player-state field instead of the actual media-type field. Because both are small integer enums, this quietly produced a wrong-but-valid media type instead of an obvious crash, with two real consequences. While music was playing, the computed type always collapsed to AUDIO no matter what was actually playing, which feeds into the gate for the "like this song" intent — so saying "like this song" while music played could get wrongly rejected. And the GAME media type could never be produced this way at all, since the player-state enum doesn't have enough values to reach it, meaning save-game and load-game intents, and the blacklist that's supposed to disable playback intents while a game is active, never actually engaged — voice commands like "save game" simply never worked while a game was playing. The fix is to read the correct field.

The second: picking among tied search results used random.choice, so the exact same query could non-deterministically return a different skill's answer each time, with no way to reproduce or reason about which one you'd get. The fix picks the first candidate encountered among ties instead, which is stable and deterministic, and removes the now-unused random import. Everything about how non-tied results get sorted and scored is unchanged.

New tests drive a real status message through the handler and then the intent matcher, proving "like this song" is reachable while music plays and "save game" is reachable while a game is active — both fail against the unfixed code and pass after. Another test runs the tie-break fifty times over a five-way tie and asserts a single consistent winner — it fails against the old random code, which produces multiple different winners, and passes after the fix. Full existing suite: 65 passed, 0 failed, 0 skipped.

This is still a draft PR. It needs human review and merge — no merge authority is claimed here.
